### PR TITLE
feat: add support for rich content

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "ts-jest": "27.0.3",
     "ts-loader": "9.2.3",
     "ts-node": "10.0.0",
-    "typescript": "4.3.4",
+    "typescript": "4.5.5",
     "webpack": "5.40.0",
     "webpack-cli": "4.7.2"
   },

--- a/src/components/options/EditorReducer.ts
+++ b/src/components/options/EditorReducer.ts
@@ -80,7 +80,11 @@ function validateEdit(
         new RegExp(action.value);
         errors.pattern = undefined;
       } catch (e) {
-        errors.pattern = e.message;
+        if (e instanceof Error) {
+          errors.pattern = e.message;
+        } else {
+          errors.pattern = `Unknown error: ${e}`;
+        }
       }
       break;
   }

--- a/src/components/popup/FunctionList.tsx
+++ b/src/components/popup/FunctionList.tsx
@@ -6,7 +6,7 @@ import {CopyFunction, filterFunctions} from '../../lib/function';
 import {getActiveTab} from '../../lib/tab';
 import {createPageTargetFromTab} from '../../lib/page';
 import {keyToIndex} from '../../lib/util';
-import {EvalResult, EvalError} from '../../lib/eval';
+import {EvalResult, EvalError, isRichContent} from '../../lib/eval';
 
 import {FunctionItem} from './Function';
 import {useEvaluate} from '../common/Sandbox';
@@ -24,7 +24,16 @@ async function availableFunctions(): Promise<CopyFunction[]> {
 
 function writeResultToClipboard(res: EvalResult) {
   if (res.result) {
-    navigator.clipboard.writeText(res.result.toString());
+    if (isRichContent(res.result)) {
+      navigator.clipboard.write([
+        new ClipboardItem({
+          'text/plain': new Blob([res.result.text], {type: 'text/plain'}),
+          'text/html': new Blob([res.result.html], {type: 'text/html'}),
+        }),
+      ]);
+    } else {
+      navigator.clipboard.writeText(res.result.toString());
+    }
   }
 }
 

--- a/src/lib/eval.ts
+++ b/src/lib/eval.ts
@@ -1,5 +1,5 @@
 import {Page, isPage} from './page';
-import {CopyResult} from './function';
+import {CopyResult, RichContent} from './function';
 
 export type EvalPayload =
   | {
@@ -33,8 +33,13 @@ function isAcceptableResult(input: any): input is CopyResult {
     typeof input === 'string' ||
     typeof input === 'number' ||
     typeof input === 'undefined' ||
-    input === null
+    input === null ||
+    isRichContent(input)
   );
+}
+
+export function isRichContent(input: any): input is RichContent {
+  return typeof input === 'object' && 'html' in input && 'text' in input;
 }
 
 function isEmpty(input: any): boolean {
@@ -76,7 +81,7 @@ export async function evaluate(request: EvalPayload): Promise<EvalResult> {
     result = await Promise.resolve(fn.call(undefined, request.page));
     if (!isAcceptableResult(result)) {
       throw new Error(
-        'returning value is not one of (string | number | null | undefined)'
+        'returning value is not one of (string | number | { html: string, text: string } | null | undefined)'
       );
     }
   } catch (e) {

--- a/src/lib/eval.ts
+++ b/src/lib/eval.ts
@@ -68,7 +68,10 @@ export async function evaluate(request: EvalPayload): Promise<EvalResult> {
   } catch (e) {
     return {
       result: null,
-      error: error('ParseError', e),
+      error: error(
+        'ParseError',
+        e instanceof Error ? e : new Error(`Unknown error: ${e}`)
+      ),
     };
   }
 
@@ -87,7 +90,10 @@ export async function evaluate(request: EvalPayload): Promise<EvalResult> {
   } catch (e) {
     return {
       result,
-      error: error('ExecutionError', e),
+      error: error(
+        'ExecutionError',
+        e instanceof Error ? e : new Error(`Unknown error: ${e}`)
+      ),
     };
   }
 

--- a/src/lib/function.ts
+++ b/src/lib/function.ts
@@ -6,7 +6,12 @@ import validate from './function.ajv';
 
 export const currentVersion = 1;
 
-export type CopyResult = string | null | undefined;
+export interface RichContent {
+  html: string;
+  text: string;
+}
+
+export type CopyResult = string | RichContent | null | undefined;
 export type CopyFn = (
   this: Library,
   t: Page

--- a/yarn.lock
+++ b/yarn.lock
@@ -5806,10 +5806,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@4.3.4:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.4.tgz#3f85b986945bcf31071decdd96cf8bfa65f9dcbc"
-  integrity sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==
+typescript@4.5.5:
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
+  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Add support for rich content.

If a function returns a `{ html: string; text: string; }`-shaped object, it will be treated and stored in the clipboard as a rich content.

A typical function goes like:

~~~javascript
page => ({
  html: render('<a href="{{&url}}">{{title}}</a>', page),
  text: page.title,
})
~~~

Could be included in predefined examples.

https://user-images.githubusercontent.com/8465/154277073-73d234ae-11e3-4dd0-ae6a-a6a46df6c18e.mov

Fixes #103 

