### PR TITLE
test: options 画面の削除・並び替え E2E テストを追加

### DIFF
--- a/e2e/options.spec.ts
+++ b/e2e/options.spec.ts
@@ -13,6 +13,49 @@ async function getStoredFunctionNames(
   });
 }
 
+async function seedStorage(
+  page: import('@playwright/test').Page,
+  functions: unknown[],
+) {
+  await page.evaluate(fns => {
+    return new Promise<void>((resolve, reject) => {
+      chrome.storage.sync.set({functions: fns}, () => {
+        if (chrome.runtime.lastError) {
+          reject(chrome.runtime.lastError);
+          return;
+        }
+        resolve();
+      });
+    });
+  }, functions);
+}
+
+// Minimal CopyFunction fixtures matching src/lib/function.ts's CopyFunction
+// shape / src/lib/function.schema.json. `pattern` is intentionally omitted.
+const threeFunctions = [
+  {
+    id: 'e2e-fn-a',
+    name: 'E2E Function A',
+    code: '() => "a"',
+    version: 1,
+    theme: {textColor: '#000000', backgroundColor: '#eeeeee'},
+  },
+  {
+    id: 'e2e-fn-b',
+    name: 'E2E Function B',
+    code: '() => "b"',
+    version: 1,
+    theme: {textColor: '#000000', backgroundColor: '#dddddd'},
+  },
+  {
+    id: 'e2e-fn-c',
+    name: 'E2E Function C',
+    code: '() => "c"',
+    version: 1,
+    theme: {textColor: '#000000', backgroundColor: '#cccccc'},
+  },
+];
+
 test('adding a function via the options UI persists to chrome.storage.sync', async ({
   context,
   extensionId,
@@ -58,4 +101,94 @@ test('adding a function via the options UI persists to chrome.storage.sync', asy
   // not just held in in-memory state).
   await options.reload();
   await expect(options.getByText(newFunctionName)).toBeVisible();
+});
+
+test('deleting a function via the options UI removes it from chrome.storage.sync', async ({
+  context,
+  extensionId,
+}) => {
+  const options = await context.newPage();
+  await options.goto(`chrome-extension://${extensionId}/options.html`);
+  await seedStorage(options, threeFunctions);
+  await options.reload();
+
+  await expect(options.getByText('E2E Function A')).toBeVisible();
+  await expect(options.getByText('E2E Function B')).toBeVisible();
+  await expect(options.getByText('E2E Function C')).toBeVisible();
+
+  // Deleting shows a native `confirm()` dialog (see the 'delete' action in
+  // src/components/options/FunctionsReducer.ts) — accept it.
+  options.on('dialog', dialog => dialog.accept());
+
+  // Open the editor for "E2E Function B" and click its Delete button.
+  await options.getByText('E2E Function B').click();
+  const deleteButton = options.getByRole('button', {name: /Delete/});
+  await expect(deleteButton).toBeVisible();
+  await deleteButton.click();
+
+  // The item disappears from the UI...
+  await expect(options.getByText('E2E Function B')).not.toBeVisible();
+  await expect(options.getByText('E2E Function A')).toBeVisible();
+  await expect(options.getByText('E2E Function C')).toBeVisible();
+
+  // ...and chrome.storage.sync no longer contains it.
+  await expect
+    .poll(() => getStoredFunctionNames(options))
+    .toEqual(['E2E Function A', 'E2E Function C']);
+
+  // Survives a reload (i.e. actually persisted, not just in-memory state).
+  await options.reload();
+  await expect(options.getByText('E2E Function B')).not.toBeVisible();
+  await expect(options.getByText('E2E Function A')).toBeVisible();
+  await expect(options.getByText('E2E Function C')).toBeVisible();
+});
+
+test('reordering functions via drag & drop persists the new order to chrome.storage.sync', async ({
+  context,
+  extensionId,
+}) => {
+  const options = await context.newPage();
+  await options.goto(`chrome-extension://${extensionId}/options.html`);
+  await seedStorage(options, threeFunctions);
+  await options.reload();
+
+  await expect(options.getByText('E2E Function A')).toBeVisible();
+  await expect(options.getByText('E2E Function B')).toBeVisible();
+  await expect(options.getByText('E2E Function C')).toBeVisible();
+
+  // Reordering uses react-dnd's HTML5Backend (see
+  // src/components/options/DnD.tsx / FunctionList.tsx). Playwright's
+  // `locator.dragTo()` performs real mouse down/move/up sequences via CDP,
+  // which Chromium translates into native HTML5 drag events, so it works
+  // here without any manual dataTransfer wiring.
+  //
+  // Each function row renders a "drag knob" (the faBars icon) as the drag
+  // handle (see DragKnob in FunctionList.tsx); grab it via the icon rather
+  // than styled-components' generated class names, which aren't stable
+  // selectors. Rows render in storage order (seeded as A, B, C above), so
+  // knob index N corresponds to the Nth seeded function.
+  const dragKnobs = options.locator('svg[data-icon="bars"] >> xpath=..');
+
+  // Drag "E2E Function A" (index 0) down past "E2E Function C" (index 2).
+  // react-dnd's hover-based reorder swaps step by step as the dragged item
+  // crosses each sibling, ending with A placed after C: [B, C, A].
+  await dragKnobs.nth(0).dragTo(dragKnobs.nth(2));
+
+  const expectedOrder = ['E2E Function B', 'E2E Function C', 'E2E Function A'];
+
+  // UI reflects the new order immediately (client-side reducer state)...
+  const nameLocator = options.locator(
+    ':text-is("E2E Function A"), :text-is("E2E Function B"), :text-is("E2E Function C")',
+  );
+  await expect(nameLocator).toHaveText(expectedOrder);
+
+  // ...and the reordered array is persisted to chrome.storage.sync on drop
+  // (see the 'dropped' action in FunctionsReducer.ts).
+  await expect
+    .poll(() => getStoredFunctionNames(options))
+    .toEqual(expectedOrder);
+
+  // Survives a reload.
+  await options.reload();
+  await expect(nameLocator).toHaveText(expectedOrder);
 });

--- a/e2e/options.spec.ts
+++ b/e2e/options.spec.ts
@@ -21,7 +21,14 @@ async function seedStorage(
     return new Promise<void>((resolve, reject) => {
       chrome.storage.sync.set({functions: fns}, () => {
         if (chrome.runtime.lastError) {
-          reject(chrome.runtime.lastError);
+          // chrome.runtime.lastError is a plain {message} object, not an
+          // Error; wrap it so page.evaluate's serialization keeps the message.
+          reject(
+            new Error(
+              chrome.runtime.lastError.message ??
+                'chrome.storage.sync.set failed',
+            ),
+          );
           return;
         }
         resolve();


### PR DESCRIPTION
## What

Phase 2 (ライブラリ置換) の準備として、options 画面の E2E テストを 2 件追加 (`e2e/options.spec.ts`):

- **削除**: 3 関数を storage に seed → エディタを開いて Delete → `confirm()` ダイアログを許可 → UI / `chrome.storage.sync` / reload 後の 3 段階で消えたことを検証
- **並び替え**: DragKnob (faBars アイコン起点のセレクタ) を `dragTo()` でドラッグ → `[B, C, A]` の順序を UI / storage / reload 後で検証

## Why

NEXT_PLAN.md Phase 2 の方針どおり、react-dnd の置き換え (dnd-kit 等) と storage 堅牢化に着手する前に、現行の削除・並び替え挙動を守る安全網を先に用意する。

## Notes for review

- react-dnd (HTML5Backend) は Playwright の `dragTo()` がそのまま動いた。CDP ベースの実マウスイベントが Chromium でネイティブ HTML5 drag イベントに変換されるため、手動の dataTransfer dispatch は不要
- セレクタは styled-components の生成クラス名 (不安定) を避け、`svg[data-icon="bars"]` などの安定属性を使用
- 並び替えの期待値 `[B, C, A]` は react-dnd の hover ベース reorder が要素を跨ぐごとに逐次 swap する挙動による (コメントで説明済み)

## Verification

- `pnpm e2e` 4/4 green を複数回確認 (このセッションで 3 連続 + 実装時に 10 連続)
- `pnpm test` (Vitest 22 + oxlint / oxfmt / tsc) green