### PR TITLE
refactor: migrate from styled-components to CSS Modules

### DIFF
--- a/NEXT_PLAN.md
+++ b/NEXT_PLAN.md
@@ -131,7 +131,7 @@ oxfmt の対象は ts/tsx/js のみ (md/html/css/json は ignore し無関係な
 並び替え・削除のテストを追加する。
 (実ページの title/url 取得は activeTab が automation で発火しない制約により E2E 対象外のまま)
 
-- **styled-components**(メンテナンスモード宣言済み)→ **CSS Modules に決定 (2026-07-19, branch: css-migration-trial)**
+- **styled-components**(メンテナンスモード宣言済み)→ **CSS Modules に決定 (2026-07-19, branch: css-migration-trial)** — **全面移行完了 (2026-07-19)**
   - 1 コンポーネント試行 (popup の Function 系 3 ファイル、動的テーマ色 + keyframes 継承の最難関ケース) の結論:
     動的テーマ色は CSS Modules / vanilla-extract どちらでも同じ CSS カスタムプロパティ
     (`style={{'--text-color': ...}}` → `var(--text-color)`) に帰着し難易度に差がない。
@@ -143,6 +143,20 @@ oxfmt の対象は ts/tsx/js のみ (md/html/css/json は ignore し無関係な
   - 残移行時の注意: `${Item} + ${Item}` コンポーネントセレクタ (options/Parts.tsx) は
     gap 等への書き換えが必要な唯一の非機械的パターン。CSS 変数の命名規約を先に決める。
     `*.module.css` の型生成ツール導入は必要になった時点で判断
+  - **実施結果**: `src/theme.css` に `theme.ts` の値を `:root` の CSS カスタムプロパティ
+    (`--space-*` / `--size-*` / `--color-*` / `--font-*` / `--constants-*`) として列挙し、
+    popup.tsx / options.tsx の両エントリで import (`code.css`/`prism.css` と同じ前例踏襲)。
+    残っていた popup (Header/App) と options 全ファイル (Button/Input/ColorInput/
+    FunctionList/InstallFunction/Parts/App) を CSS Modules に変換。
+    `${Item} + ${Item}` は `Row` を `display:flex; gap: 0 var(--space-4)` にする方針で解消
+    (見た目上は隣接要素間のみに margin が付く元の挙動と、gap による「全アイテム間」の
+    間隔が実質的に同一になる並びのみだったため採用)。`$mode` 等のバリアントは
+    `styles.primary`/`styles.danger` のクラス切替に置換。`ThemeProvider` は popup/App.tsx,
+    options/App.tsx, common/ForTest.tsx から撤去、`styled-components` を `pnpm remove`、
+    `src/styled.d.ts` を削除。`options/CodeEditor.tsx` は styled-components ではなく
+    `react-simple-code-editor` に TS の値として直接テーマ値を渡す箇所のため `Theme.ts` を
+    そのまま import し続ける唯一の残存箇所として温存。
+    `pnpm test` (22 vitest + check) / `pnpm run build` / `pnpm e2e` (4/4) 全て green。
 - **react-dnd**(実質未メンテ)→ `dnd-kit` か `pragmatic-drag-and-drop`
   - 関数が多くなった時の並び替え性能にも直結
 - **prismjs + react-simple-code-editor** → CodeMirror 6(編集体験も改善)

--- a/NEXT_PLAN.md
+++ b/NEXT_PLAN.md
@@ -131,9 +131,18 @@ oxfmt の対象は ts/tsx/js のみ (md/html/css/json は ignore し無関係な
 並び替え・削除のテストを追加する。
 (実ページの title/url 取得は activeTab が automation で発火しない制約により E2E 対象外のまま)
 
-- **styled-components**(メンテナンスモード宣言済み)→ CSS Modules か vanilla-extract
+- **styled-components**(メンテナンスモード宣言済み)→ **CSS Modules に決定 (2026-07-19, branch: css-migration-trial)**
+  - 1 コンポーネント試行 (popup の Function 系 3 ファイル、動的テーマ色 + keyframes 継承の最難関ケース) の結論:
+    動的テーマ色は CSS Modules / vanilla-extract どちらでも同じ CSS カスタムプロパティ
+    (`style={{'--text-color': ...}}` → `var(--text-color)`) に帰着し難易度に差がない。
+    vanilla-extract は静的スタイルの型安全で勝るが依存 2〜3 個 + Vite プラグインが必要で、
+    Vite ネイティブ・追加依存ゼロの CSS Modules が「薄く、脱出容易」方針に沿う。
+    詳細は tmp/css-migration-notes.md (利用パターン分類 37 定義/10 ファイル、
+    ThemeProvider → :root CSS 変数 + コンポーネントローカル変数の二層構造案を含む)
   - UI 全面に及ぶので一括ではなくコンポーネント単位で段階移行
-  - 最初に 1 コンポーネントで試してから移行先を確定する
+  - 残移行時の注意: `${Item} + ${Item}` コンポーネントセレクタ (options/Parts.tsx) は
+    gap 等への書き換えが必要な唯一の非機械的パターン。CSS 変数の命名規約を先に決める。
+    `*.module.css` の型生成ツール導入は必要になった時点で判断
 - **react-dnd**(実質未メンテ)→ `dnd-kit` か `pragmatic-drag-and-drop`
   - 関数が多くなった時の並び替え性能にも直結
 - **prismjs + react-simple-code-editor** → CodeMirror 6(編集体験も改善)
@@ -172,5 +181,5 @@ Firefox / Safari は非対応のため、ユーザーコード実行の仕組み
 |---|---|
 | パッケージマネージャ | **決定済み (2026-07-18): pnpm**。npm (最薄・脱出容易だが速度と厳密さで劣る) と bun (最速だがランタイムごと寄せる意図がないなら PM だけ使う旨味が薄い) も検討した上で、速度・ディスク効率・幽霊依存検出・corepack でのバージョン固定を評価して pnpm を選択 |
 | フォーマッタ(oxfmt / Biome / Prettier 継続) | **決定済み (2026-07-18): oxfmt + oxlint**。oxc に一本化。Vite+ (oxlint/oxfmt/tsgo を束ねる統合ツール) は 2026-07-02 に beta が出たばかりのため今回は見送り、stable 到達時に再検討 |
-| styled-components の移行先 | Phase 2 冒頭に 1 コンポーネントで試してから |
+| styled-components の移行先 | **決定済み (2026-07-19): CSS Modules**。1 コンポーネント試行の結果、最難関の動的テーマ色で vanilla-extract と難易度差がなく、追加依存ゼロの CSS Modules が方針に合致 |
 | Safari をスコープに入れるか | Phase 3 の設計には影響しない(QuickJS 案ならどちらでも同じ)ので後回しで OK |

--- a/package.json
+++ b/package.json
@@ -48,8 +48,7 @@
     "react-dnd-html5-backend": "16.0.1",
     "react-dom": "19.2.7",
     "react-router-dom": "7.18.1",
-    "react-simple-code-editor": "0.14.1",
-    "styled-components": "6.4.3"
+    "react-simple-code-editor": "0.14.1"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,9 +56,6 @@ importers:
       react-simple-code-editor:
         specifier: 0.14.1
         version: 0.14.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      styled-components:
-        specifier: 6.4.3
-        version: 6.4.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@playwright/test':
         specifier: ^1.61.1
@@ -217,12 +214,6 @@ packages:
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
-
-  '@emotion/is-prop-valid@1.4.0':
-    resolution: {integrity: sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==}
-
-  '@emotion/memoize@0.9.0':
-    resolution: {integrity: sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==}
 
   '@exodus/bytes@1.15.1':
     resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
@@ -1540,25 +1531,6 @@ packages:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
 
-  styled-components@6.4.3:
-    resolution: {integrity: sha512-wYXrhu+JmDjZ1Tv7O0OopGTfztbzun43Pjjhh2H+xc0h5A09dwpZ5FJbrifJDcL8g5TA9btpWOX2+iSRuJTExw==}
-    engines: {node: '>= 16'}
-    peerDependencies:
-      css-to-react-native: '>= 3.2.0'
-      react: '>= 16.8.0'
-      react-dom: '>= 16.8.0'
-      react-native: '>= 0.68.0'
-    peerDependenciesMeta:
-      css-to-react-native:
-        optional: true
-      react-dom:
-        optional: true
-      react-native:
-        optional: true
-
-  stylis@4.3.6:
-    resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
-
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -1846,12 +1818,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
-
-  '@emotion/is-prop-valid@1.4.0':
-    dependencies:
-      '@emotion/memoize': 0.9.0
-
-  '@emotion/memoize@0.9.0': {}
 
   '@exodus/bytes@1.15.1': {}
 
@@ -2964,17 +2930,6 @@ snapshots:
   strip-indent@3.0.0:
     dependencies:
       min-indent: 1.0.1
-
-  styled-components@6.4.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
-    dependencies:
-      '@emotion/is-prop-valid': 1.4.0
-      csstype: 3.2.3
-      react: 19.2.7
-      stylis: 4.3.6
-    optionalDependencies:
-      react-dom: 19.2.7(react@19.2.7)
-
-  stylis@4.3.6: {}
 
   symbol-tree@3.2.4: {}
 

--- a/src/components/common/ForTest.tsx
+++ b/src/components/common/ForTest.tsx
@@ -1,8 +1,5 @@
 import React from 'react';
-import {ThemeProvider} from 'styled-components';
-
-import {theme} from '../common/Theme';
 
 export const Wrapper = (props: {children?: React.ReactNode}) => {
-  return <ThemeProvider theme={theme}>{props.children}</ThemeProvider>;
+  return <>{props.children}</>;
 };

--- a/src/components/common/FunctionParts.module.css
+++ b/src/components/common/FunctionParts.module.css
@@ -2,8 +2,8 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  width: var(--function-width, 380px);
-  height: var(--function-height, 32px);
+  width: var(--constants-functionWidth);
+  height: var(--constants-functionHeight);
   padding: var(--space-1, 0.25rem) var(--space-2, 0.5rem);
   color: var(--text-color);
   background-color: var(--background-color);
@@ -23,8 +23,7 @@
   padding: 0 var(--space-1, 0.25rem);
   margin-right: var(--space-2, 0.5rem);
   font-size: var(--size-lg, 1.125rem);
-  font-family: Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
-    monospace;
+  font-family: var(--font-monospace);
 
   border-radius: var(--space-1, 0.25rem);
   border: 2px solid var(--text-color);

--- a/src/components/common/FunctionParts.module.css
+++ b/src/components/common/FunctionParts.module.css
@@ -1,0 +1,54 @@
+.functionBox {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: var(--function-width, 380px);
+  height: var(--function-height, 32px);
+  padding: var(--space-1, 0.25rem) var(--space-2, 0.5rem);
+  color: var(--text-color);
+  background-color: var(--background-color);
+  cursor: pointer;
+}
+.functionBox:focus,
+.functionBox:hover {
+  filter: brightness(110%);
+}
+
+.shortcutBox {
+  width: 32px;
+}
+
+.shortcutKey {
+  text-align: center;
+  padding: 0 var(--space-1, 0.25rem);
+  margin-right: var(--space-2, 0.5rem);
+  font-size: var(--size-lg, 1.125rem);
+  font-family: Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+    monospace;
+
+  border-radius: var(--space-1, 0.25rem);
+  border: 2px solid var(--text-color);
+  box-shadow: 2px 2px 0px 0px rgba(0, 0, 0, 0.3);
+}
+
+.functionName {
+  font-size: var(--size-base, 1rem);
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  user-select: none; /* prevent accidental selection for form */
+}
+
+.rightIconBox {
+  margin-left: auto;
+  width: var(--size-lg, 1.125rem);
+  color: var(--icon-color);
+}
+
+.addNewFunctionBox {
+  border: 1px solid var(--text-color);
+}
+.addNewFunctionBox:hover {
+  color: var(--color-primary, #007bff);
+  border-color: var(--color-primary, #007bff);
+}

--- a/src/components/common/FunctionParts.tsx
+++ b/src/components/common/FunctionParts.tsx
@@ -1,45 +1,48 @@
 import React, {useCallback} from 'react';
-import styled from 'styled-components';
 
 import {CopyFunction} from '../../lib/function';
 import {PatternIcon} from './Icon';
+import {theme} from './Theme';
+
+import styles from './FunctionParts.module.css';
 
 export type FunctionBoxProps = {
   $textColor: string;
   $backgroundColor: string;
 };
 
-export const FunctionBox = styled.div<FunctionBoxProps>`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  width: ${props => props.theme.constants.functionWidth};
-  height: ${props => props.theme.constants.functionHeight};
-  padding: ${props => props.theme.space[1]} ${props => props.theme.space[2]};
-  color: ${props => props.$textColor};
-  background-color: ${props => props.$backgroundColor};
-  &:focus,
-  &:hover {
-    filter: brightness(110%);
-  }
-  cursor: pointer;
-`;
+// CSS custom properties shared by FunctionBox and its descendants that need
+// per-function dynamic colors (was styled-components props -> theme interpolation).
+function functionBoxVars(props: FunctionBoxProps): React.CSSProperties {
+  return {
+    '--text-color': props.$textColor,
+    '--background-color': props.$backgroundColor,
+    '--function-width': theme.constants.functionWidth,
+    '--function-height': theme.constants.functionHeight,
+  } as React.CSSProperties;
+}
 
-const ShortcutBox = styled.div`
-  width: 32px;
-`;
+export const FunctionBox = React.forwardRef<
+  HTMLDivElement,
+  FunctionBoxProps &
+    Omit<React.HTMLAttributes<HTMLDivElement>, 'className' | 'style'> & {
+      className?: string;
+    }
+>(function FunctionBox(props, ref) {
+  const {$textColor, $backgroundColor, className, ...rest} = props;
+  return (
+    <div
+      ref={ref}
+      className={[styles.functionBox, className].filter(Boolean).join(' ')}
+      style={functionBoxVars({$textColor, $backgroundColor})}
+      {...rest}
+    />
+  );
+});
 
-const ShortcutKey = styled.kbd<{$textColor: string}>`
-  text-align: center;
-  padding: 0 ${props => props.theme.space[1]};
-  margin-right: ${props => props.theme.space[2]};
-  font-size: ${props => props.theme.size.lg};
-  font-family: ${props => props.theme.fontFamily.monospace};
-
-  border-radius: ${props => props.theme.space[1]};
-  border: 2px solid ${props => props.$textColor};
-  box-shadow: 2px 2px 0px 0px rgba(0, 0, 0, 0.3);
-`;
+const ShortcutBox = (props: {children?: React.ReactNode}) => (
+  <div className={styles.shortcutBox}>{props.children}</div>
+);
 
 type ShortcutProps = {
   textColor: string;
@@ -49,26 +52,33 @@ type ShortcutProps = {
 export function Shortcut(props: ShortcutProps) {
   return typeof props.shortcut !== 'undefined' ? (
     <ShortcutBox>
-      <ShortcutKey $textColor={props.textColor}>{props.shortcut}</ShortcutKey>
+      <kbd
+        className={styles.shortcutKey}
+        style={{'--text-color': props.textColor} as React.CSSProperties}
+      >
+        {props.shortcut}
+      </kbd>
     </ShortcutBox>
   ) : (
     <ShortcutBox />
   );
 }
 
-export const FunctionName = styled.div`
-  font-size: ${props => props.theme.size.base};
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  user-select: none; /* prevent accidental selection for form */
-`;
+export const FunctionName = (props: {children?: React.ReactNode}) => (
+  <div className={styles.functionName}>{props.children}</div>
+);
 
-export const RigthIconBox = styled.div<{$color: string}>`
-  margin-left: auto;
-  width: ${p => p.theme.size.lg};
-  color: ${p => p.$color};
-`;
+export const RigthIconBox = (props: {
+  $color: string;
+  children?: React.ReactNode;
+}) => (
+  <div
+    className={styles.rightIconBox}
+    style={{'--icon-color': props.$color} as React.CSSProperties}
+  >
+    {props.children}
+  </div>
+);
 
 type FunctionItemProps = {
   fn: CopyFunction;
@@ -98,23 +108,16 @@ export function FunctionItem(props: FunctionItemProps) {
   );
 }
 
-const AddNewFunctionBox = styled(FunctionBox)`
-  border: 1px solid ${p => p.$textColor};
-  &:hover {
-    color: ${p => p.theme.color.primary};
-    border-color: ${p => p.theme.color.primary};
-  }
-`;
-
 export function AddFunctionItem(props: {onClick?: () => void}) {
   return (
-    <AddNewFunctionBox
+    <FunctionBox
+      className={styles.addNewFunctionBox}
       $textColor="#010203"
       $backgroundColor="#FFF"
       onClick={props.onClick}
     >
       <ShortcutBox />
       <FunctionName>Create New Function</FunctionName>
-    </AddNewFunctionBox>
+    </FunctionBox>
   );
 }

--- a/src/components/common/FunctionParts.tsx
+++ b/src/components/common/FunctionParts.tsx
@@ -2,7 +2,6 @@ import React, {useCallback} from 'react';
 
 import {CopyFunction} from '../../lib/function';
 import {PatternIcon} from './Icon';
-import {theme} from './Theme';
 
 import styles from './FunctionParts.module.css';
 
@@ -17,8 +16,6 @@ function functionBoxVars(props: FunctionBoxProps): React.CSSProperties {
   return {
     '--text-color': props.$textColor,
     '--background-color': props.$backgroundColor,
-    '--function-width': theme.constants.functionWidth,
-    '--function-height': theme.constants.functionHeight,
   } as React.CSSProperties;
 }
 

--- a/src/components/options/App.tsx
+++ b/src/components/options/App.tsx
@@ -1,7 +1,5 @@
 import {Routes, Route} from 'react-router-dom';
-import {ThemeProvider} from 'styled-components';
 
-import {theme} from '../common/Theme';
 import {FunctionList} from './FunctionList';
 import {Hint, DebuggingHint} from './Hints';
 import {InstallFunction} from './InstallFunction';
@@ -27,15 +25,13 @@ const PageInstall = () => (
 
 export const App = () => {
   return (
-    <ThemeProvider theme={theme}>
-      <MainColumn>
-        <Title />
-        <Routes>
-          <Route path="/" element={<PageRoot />} />
-          <Route path="/install" element={<PageInstall />} />
-        </Routes>
-        <VersionLabel />
-      </MainColumn>
-    </ThemeProvider>
+    <MainColumn>
+      <Title />
+      <Routes>
+        <Route path="/" element={<PageRoot />} />
+        <Route path="/install" element={<PageInstall />} />
+      </Routes>
+      <VersionLabel />
+    </MainColumn>
   );
 };

--- a/src/components/options/Button.module.css
+++ b/src/components/options/Button.module.css
@@ -1,0 +1,26 @@
+.button {
+  padding: var(--space-2);
+  background-color: transparent;
+  border: solid 1px;
+  border-radius: var(--space-1);
+  cursor: pointer;
+}
+
+.primary:hover:not(:disabled),
+.primary:focus:not(:disabled) {
+  color: var(--color-primary);
+  border-color: var(--color-primary);
+  outline-color: var(--color-primary);
+}
+
+.danger {
+  color: var(--color-danger);
+}
+.danger:hover:not(:disabled),
+.danger:focus:not(:disabled) {
+  outline-color: var(--color-danger);
+}
+
+.buttonIcon {
+  margin-right: var(--space-1);
+}

--- a/src/components/options/Button.tsx
+++ b/src/components/options/Button.tsx
@@ -1,33 +1,8 @@
 import React, {useCallback} from 'react';
-import styled, {css} from 'styled-components';
+
+import styles from './Button.module.css';
 
 type ButtonMode = 'default' | 'danger';
-
-const primary = css`
-  &:hover:not(:disabled),
-  &:focus:not(:disabled) {
-    color: ${props => props.theme.color.primary};
-    border-color: ${props => props.theme.color.primary};
-    outline-color: ${p => p.theme.color.primary};
-  }
-`;
-
-const danger = css`
-  color: ${p => p.theme.color.danger};
-  &:hover:not(:disabled),
-  &:focus:not(:disabled) {
-    outline-color: ${p => p.theme.color.danger};
-  }
-`;
-
-const ButtonStyle = styled.button<{$mode?: ButtonMode}>`
-  padding: ${props => props.theme.space[2]};
-  background-color: transparent;
-  border: solid 1px;
-  border-radius: ${props => props.theme.space[1]};
-  cursor: pointer;
-  ${p => (p.$mode === 'danger' ? danger : primary)};
-`;
 
 export const Button = (props: {
   mode?: ButtonMode;
@@ -43,18 +18,20 @@ export const Button = (props: {
     [props.onClick],
   );
 
+  const modeClass = props.mode === 'danger' ? styles.danger : styles.primary;
+
   return (
-    <ButtonStyle
+    <button
       type="button"
-      $mode={props.mode}
+      className={[styles.button, modeClass].join(' ')}
       onClick={onClick as any}
       disabled={props.disabled}
     >
       {props.children}
-    </ButtonStyle>
+    </button>
   );
 };
 
-export const ButtonIcon = styled.i`
-  margin-right: ${p => p.theme.space[1]};
-`;
+export const ButtonIcon = (props: {children?: React.ReactNode}) => (
+  <i className={styles.buttonIcon}>{props.children}</i>
+);

--- a/src/components/options/ColorInput.module.css
+++ b/src/components/options/ColorInput.module.css
@@ -1,0 +1,39 @@
+.inputWrap {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.colorPickerBox {
+  position: relative;
+  margin-left: calc(var(--size-2xl) * -1);
+  font-size: var(--size-lg);
+  cursor: pointer;
+}
+
+.paletteBox {
+  position: absolute;
+  z-index: 999;
+  background-color: #fff;
+
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+
+  width: 130px;
+  margin-top: var(--space-2);
+  padding: var(--space-1);
+  border: 1px solid var(--color-gray);
+}
+
+.paletteColorBox {
+  background-color: var(--palette-color);
+  width: var(--size-2xl);
+  height: var(--size-2xl);
+  margin: var(--space-1);
+  cursor: pointer;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/src/components/options/ColorInput.tsx
+++ b/src/components/options/ColorInput.tsx
@@ -2,52 +2,26 @@ import {faPalette} from '@fortawesome/free-solid-svg-icons/faPalette';
 import {faRandom} from '@fortawesome/free-solid-svg-icons/faRandom';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import chroma from 'chroma-js';
-import {useCallback, useEffect, useRef} from 'react';
-import styled from 'styled-components';
+import React, {useCallback, useEffect, useRef} from 'react';
 
 import {colorPalette} from '../../lib/function';
-import {theme} from '../common/Theme';
 import {InputBox, Label, Input} from './Input';
 
-const InputWrap = styled.div`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-`;
+import styles from './ColorInput.module.css';
 
-const ColorPickerBox = styled.div`
-  position: relative;
-  margin-left: -${props => props.theme.size['2xl']};
-  font-size: ${props => props.theme.size.lg};
-  cursor: pointer;
-`;
-
-const PaletteBox = styled.div`
-  position: absolute;
-  z-index: 999;
-  background-color: #fff;
-
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-
-  width: 130px;
-  margin-top: ${props => props.theme.space[2]};
-  padding: ${props => props.theme.space[1]};
-  border: 1px solid ${props => props.theme.color.gray};
-`;
-
-const PaletteColorBox = styled.div<{$color: string}>`
-  background-color: ${props => props.$color};
-  width: ${props => props.theme.size['2xl']};
-  height: ${props => props.theme.size['2xl']};
-  margin: ${props => props.theme.space[1]};
-  cursor: pointer;
-
-  display: flex;
-  justify-content: center;
-  align-items: center;
-`;
+const PaletteColorBox = (props: {
+  $color: string;
+  onClick: () => void;
+  children?: React.ReactNode;
+}) => (
+  <div
+    className={styles.paletteColorBox}
+    style={{'--palette-color': props.$color} as React.CSSProperties}
+    onClick={props.onClick}
+  >
+    {props.children}
+  </div>
+);
 
 const PaletteColor = (props: {
   color: string;
@@ -96,22 +70,22 @@ export function ColorPicker(props: ColorPickerProps) {
   }, [props.show, props.togglePalette]);
 
   return (
-    <ColorPickerBox ref={ref}>
+    <div className={styles.colorPickerBox} ref={ref}>
       <FontAwesomeIcon
         icon={faPalette}
         onClick={props.togglePalette}
-        color={props.show ? theme.color.primary : undefined}
+        color={props.show ? 'var(--color-primary)' : undefined}
         data-testid="toggle-palette"
       />
       {props.show && (
-        <PaletteBox data-testid="palette">
+        <div className={styles.paletteBox} data-testid="palette">
           {colorPalette.map((c, i) => (
             <PaletteColor key={i} color={c} onClick={props.onSelect} />
           ))}
           <PaletteColorRandom onClick={props.onSelect} />
-        </PaletteBox>
+        </div>
       )}
-    </ColorPickerBox>
+    </div>
   );
 }
 
@@ -141,7 +115,7 @@ export function ColorInput(props: ColorInputProps) {
   return (
     <InputBox>
       <Label htmlFor="color">Color</Label>
-      <InputWrap>
+      <div className={styles.inputWrap}>
         <Input
           type="text"
           value={props.value}
@@ -158,7 +132,7 @@ export function ColorInput(props: ColorInputProps) {
           onSelect={onSelect}
           togglePalette={props.togglePalette}
         />
-      </InputWrap>
+      </div>
     </InputBox>
   );
 }

--- a/src/components/options/FunctionList.module.css
+++ b/src/components/options/FunctionList.module.css
@@ -1,0 +1,41 @@
+.functionItemBox {
+  opacity: 1;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+.functionItemBox.dragging {
+  opacity: 0.5;
+  margin-top: var(--space-1);
+  margin-bottom: var(--space-1);
+}
+
+.itemButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--size-4xl);
+  height: var(--constants-functionHeight);
+  cursor: pointer;
+}
+
+.dragKnobBox {
+  width: var(--size-4xl);
+  opacity: 0.3;
+  cursor: default;
+}
+.dragKnobBox.draggable {
+  opacity: 1;
+  cursor: move;
+}
+
+.editorBox {
+  margin-left: var(--size-4xl);
+  margin-bottom: var(--size-4xl);
+}
+
+.addFunctionBox {
+  margin-top: var(--space-2);
+}

--- a/src/components/options/FunctionList.tsx
+++ b/src/components/options/FunctionList.tsx
@@ -4,7 +4,6 @@ import {faCaretRight} from '@fortawesome/free-solid-svg-icons/faCaretRight';
 import {faPlus} from '@fortawesome/free-solid-svg-icons/faPlus';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {useEffect, useCallback, useRef, useReducer} from 'react';
-import styled from 'styled-components';
 
 import {getCopyFunctions} from '../../lib/config';
 import {CopyFunction} from '../../lib/function';
@@ -15,64 +14,47 @@ import {reducer, initialState, DispatchType} from './FunctionsReducer';
 import {Section} from './Parts';
 import {useSubscribeFunctions} from './Subscribe';
 
-const FunctionItemBox = styled.div<{$isDragging?: boolean}>`
-  opacity: ${props => (props.$isDragging ? 0.5 : 1)};
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  margin-top: ${props => (props.$isDragging ? props.theme.space[1] : 0)};
-  margin-bottom: ${props => (props.$isDragging ? props.theme.space[1] : 0)};
-`;
-
-const ItemButton = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: ${props => props.theme.size['4xl']};
-  height: ${props => props.theme.constants.functionHeight};
-  cursor: pointer;
-`;
+import styles from './FunctionList.module.css';
 
 const Caret = (props: {active: boolean; onClick: () => void}) => {
   const {active, onClick} = props;
   return (
-    <ItemButton onClick={onClick}>
+    <div className={styles.itemButton} onClick={onClick}>
       <FontAwesomeIcon icon={active ? faCaretDown : faCaretRight} size="lg" />
-    </ItemButton>
+    </div>
   );
 };
-
-const DragKnobBox = styled(ItemButton)<{draggable?: boolean}>`
-  width: ${props => props.theme.size['4xl']};
-  opacity: ${props => (props.draggable ? 1 : 0.3)};
-  cursor: ${props => (props.draggable ? 'move' : 'default')};
-`;
 
 const DragKnob = (props: {draggable: boolean}) => {
   return (
-    <DragKnobBox draggable={props.draggable}>
+    // dragKnobBox extends itemButton (was styled(ItemButton)); keep both
+    // classes so the flex centering and size come from itemButton.
+    <div
+      className={[
+        styles.itemButton,
+        styles.dragKnobBox,
+        props.draggable ? styles.draggable : '',
+      ]
+        .join(' ')
+        .trim()}
+    >
       <FontAwesomeIcon icon={faBars} />
-    </DragKnobBox>
+    </div>
   );
 };
 
-export const EditorBox = styled.div`
-  margin-left: ${props => props.theme.size['4xl']};
-  margin-bottom: ${props => props.theme.size['4xl']};
-`;
-
-const AddFunctionBox = styled.div`
-  margin-top: ${props => props.theme.space[2]};
-`;
+export function EditorBox(props: {children?: React.ReactNode}) {
+  return <div className={styles.editorBox}>{props.children}</div>;
+}
 
 function AddFunction(props: {onClick: () => void}) {
   return (
-    <FunctionItemBox>
-      <ItemButton onClick={props.onClick}>
+    <div className={styles.functionItemBox}>
+      <div className={styles.itemButton} onClick={props.onClick}>
         <FontAwesomeIcon icon={faPlus} />
-      </ItemButton>
+      </div>
       <AddFunctionItem onClick={props.onClick} />
-    </FunctionItemBox>
+    </div>
   );
 }
 
@@ -113,7 +95,11 @@ function FunctionListItem(props: FunctionListItemProps) {
 
   return (
     <div ref={ref}>
-      <FunctionItemBox $isDragging={isDragging}>
+      <div
+        className={[styles.functionItemBox, isDragging ? styles.dragging : '']
+          .join(' ')
+          .trim()}
+      >
         <Caret active={active} onClick={onClick} />
         <FunctionItem fn={fn} onClick={onClick} />
         <div
@@ -123,7 +109,7 @@ function FunctionListItem(props: FunctionListItemProps) {
         >
           <DragKnob draggable={draggable} />
         </div>
-      </FunctionItemBox>
+      </div>
       {active && (
         <EditorBox>
           <Editor function={fn} dispatch={dispatch} />
@@ -165,7 +151,7 @@ export function FunctionList() {
         ))}
 
         {/* New Function */}
-        <AddFunctionBox>
+        <div className={styles.addFunctionBox}>
           {state.activeId !== 'new' ? (
             <AddFunction onClick={onClickAdd} />
           ) : (
@@ -177,7 +163,7 @@ export function FunctionList() {
               dispatch={dispatch}
             />
           )}
-        </AddFunctionBox>
+        </div>
       </DnDWrapper>
     </Section>
   );

--- a/src/components/options/Input.module.css
+++ b/src/components/options/Input.module.css
@@ -1,0 +1,39 @@
+.inputBox {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  margin-bottom: var(--space-2);
+  border-radius: var(--space-1);
+}
+
+.label {
+  font-size: var(--size-lg);
+  margin: var(--space-2) 0;
+  display: flex;
+}
+
+.labelSub {
+  margin-left: var(--space-2);
+  font-size: var(--size-sm);
+  align-self: flex-end;
+  color: var(--color-gray);
+}
+
+.input {
+  padding: var(--space-1);
+  font-size: var(--size-lg);
+  width: 100%;
+  border: 1px solid;
+  border-color: inherit;
+}
+.input.error {
+  border-color: var(--color-error);
+}
+.input.error:focus {
+  outline-color: var(--color-error);
+}
+
+.errorMessage {
+  color: var(--color-error);
+  margin-left: var(--space-1);
+}

--- a/src/components/options/Input.tsx
+++ b/src/components/options/Input.tsx
@@ -1,43 +1,43 @@
 import React, {useCallback} from 'react';
-import styled from 'styled-components';
 
-export const InputBox = styled.div`
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  margin-bottom: ${props => props.theme.space[2]};
-  border-radius: ${props => props.theme.space[1]};
-`;
+import styles from './Input.module.css';
 
-export const Label = styled.label`
-  font-size: ${props => props.theme.size.lg};
-  margin: ${props => props.theme.space[2]} 0;
-  display: flex;
-`;
+export const InputBox = (props: {children?: React.ReactNode}) => (
+  <div className={styles.inputBox}>{props.children}</div>
+);
 
-export const LabelSub = styled.span`
-  margin-left: ${props => props.theme.space[2]};
-  font-size: ${props => props.theme.size.sm};
-  align-self: flex-end;
-  color: ${props => props.theme.color.gray};
-`;
+export const Label = (props: {
+  htmlFor?: string;
+  children?: React.ReactNode;
+}) => (
+  <label className={styles.label} htmlFor={props.htmlFor}>
+    {props.children}
+  </label>
+);
 
-export const Input = styled.input<{$error?: boolean}>`
-  padding: ${props => props.theme.space[1]};
-  font-size: ${props => props.theme.size.lg};
-  width: 100%;
-  border: 1px solid;
+export const LabelSub = (props: {children?: React.ReactNode}) => (
+  <span className={styles.labelSub}>{props.children}</span>
+);
 
-  border-color: ${p => (p.$error ? p.theme.color.error : 'inherit')};
-  &:focus {
-    ${p => p.$error && `outline-color: ${p.theme.color.error}`};
+export const Input = React.forwardRef<
+  HTMLInputElement,
+  Omit<React.InputHTMLAttributes<HTMLInputElement>, 'className'> & {
+    $error?: boolean;
   }
-`;
+>(function Input(props, ref) {
+  const {$error, ...rest} = props;
+  return (
+    <input
+      ref={ref}
+      className={[styles.input, $error ? styles.error : ''].join(' ').trim()}
+      {...rest}
+    />
+  );
+});
 
-export const ErrorMessage = styled.span`
-  color: ${p => p.theme.color.error};
-  margin-left: ${p => p.theme.space[1]};
-`;
+export const ErrorMessage = (props: {children?: React.ReactNode}) => (
+  <span className={styles.errorMessage}>{props.children}</span>
+);
 
 export const TextInput = (props: {
   label: string;

--- a/src/components/options/InstallFunction.module.css
+++ b/src/components/options/InstallFunction.module.css
@@ -1,0 +1,11 @@
+.noticeFrame {
+  border: 1px solid var(--color-warning);
+  color: var(--color-warning);
+  margin-bottom: var(--space-4);
+}
+
+.center {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}

--- a/src/components/options/InstallFunction.tsx
+++ b/src/components/options/InstallFunction.tsx
@@ -2,7 +2,6 @@ import {faDizzy} from '@fortawesome/free-solid-svg-icons/faDizzy';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {memo, useReducer, useMemo} from 'react';
 import {useLocation} from 'react-router-dom';
-import styled from 'styled-components';
 
 import {addCopyFunctions} from '../../lib/config';
 import {CopyFunction, isCopyFunction} from '../../lib/function';
@@ -12,6 +11,8 @@ import {Editor} from './Editor';
 import {EditorBox} from './FunctionList';
 import {Action} from './FunctionsReducer';
 import {Section, TextList} from './Parts';
+
+import styles from './InstallFunction.module.css';
 
 interface State {
   fn?: CopyFunction;
@@ -40,34 +41,23 @@ function reduce(state: State, action: Action): State {
   }
 }
 
-const NoticeFrame = styled.div`
-  border: 1px solid ${p => p.theme.color.warning};
-  color: ${p => p.theme.color.warning};
-  margin-bottom: ${p => p.theme.space[4]};
-`;
 const Notice = memo(() => {
   return (
-    <NoticeFrame>
+    <div className={styles.noticeFrame}>
       <TextList>
         <li>Sharing this URL makes others can use this function.</li>
         <li>You can edit the code and every fields before installation.</li>
       </TextList>
-    </NoticeFrame>
+    </div>
   );
 });
 
-const Center = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-`;
-
 const FailedMessage = memo(() => {
   return (
-    <Center>
+    <div className={styles.center}>
       <FontAwesomeIcon icon={faDizzy} size="10x" />
       <h3>This URL is broken.</h3>
-    </Center>
+    </div>
   );
 });
 

--- a/src/components/options/Parts.module.css
+++ b/src/components/options/Parts.module.css
@@ -1,0 +1,91 @@
+.mainColumn {
+  padding: 0;
+  width: 840px;
+  margin: 20px auto;
+}
+
+.titleIcon {
+  display: inline-block;
+  background: no-repeat center/contain url('../../img/logo.png');
+  width: 123px;
+  height: 60px;
+  filter: none;
+}
+.titleIcon.dev {
+  filter: invert(24%) sepia(85%) saturate(3947%) hue-rotate(167deg)
+    brightness(93%) contrast(101%);
+}
+
+.sectionBox {
+  margin-bottom: var(--space-8);
+}
+
+.sectionTitleHeader {
+  font-family: var(--font-monospace);
+  font-size: var(--size-xl);
+}
+
+.sectionInner {
+  margin-left: var(--space-2);
+}
+
+.textList {
+  font-size: var(--size-sm);
+  margin-bottom: var(--space-4);
+}
+.textList li {
+  margin-bottom: var(--space-2);
+}
+.textList code {
+  font-size: var(--size-xs);
+  font-family: var(--font-monospace);
+  background-color: var(--color-codeBg);
+}
+
+.box {
+  display: flex;
+  flex-flow: column wrap;
+}
+
+.item {
+  display: flex;
+  flex-grow: var(--item-grow, 0);
+}
+
+/* Row lays out Items in a wrapping flex row. The gap between adjacent
+   Items replaces styled-components' `${Item} + ${Item}` component
+   selector (no CSS Modules equivalent for generated-class adjacency). */
+.row {
+  display: flex;
+  flex-flow: row wrap;
+  gap: 0 var(--space-4);
+}
+
+.dividerH {
+  margin: var(--space-4) 0;
+  height: var(--space-1);
+  background: linear-gradient(
+    90deg,
+    transparent 20%,
+    var(--color-lightgray) 20%,
+    var(--color-lightgray) 80%,
+    transparent 80%
+  );
+}
+
+.dividerV {
+  margin: 0 var(--space-2);
+  width: var(--space-1);
+  height: 100%;
+  background: linear-gradient(
+    180deg,
+    transparent 20%,
+    var(--color-lightgray) 20%,
+    var(--color-lightgray) 80%,
+    transparent 80%
+  );
+}
+
+.center {
+  text-align: center;
+}

--- a/src/components/options/Parts.tsx
+++ b/src/components/options/Parts.tsx
@@ -1,26 +1,13 @@
 import React, {memo, useMemo} from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components';
 
 import {isDev} from '../../lib/util';
 
-export const MainColumn = styled.div`
-  padding: 0;
-  width: 840px;
-  margin: 20px auto;
-`;
+import styles from './Parts.module.css';
 
-const TitleIcon = styled.div<{$dev: boolean}>`
-  display: inline-block;
-  background: no-repeat center/contain url('img/logo.png');
-  width: 123px;
-  height: 60px;
-
-  filter: ${props =>
-    props.$dev
-      ? 'invert(24%) sepia(85%) saturate(3947%) hue-rotate(167deg) brightness(93%) contrast(101%)'
-      : 'none'};
-`;
+export const MainColumn = (props: {children?: React.ReactNode}) => (
+  <div className={styles.mainColumn}>{props.children}</div>
+);
 
 export const Title = memo(() => {
   const dev = useMemo(() => isDev(), []);
@@ -28,87 +15,57 @@ export const Title = memo(() => {
   return (
     <header>
       <Link to="/">
-        <TitleIcon $dev={dev} />
+        <div
+          className={[styles.titleIcon, dev ? styles.dev : ''].join(' ').trim()}
+        />
       </Link>
     </header>
   );
 });
 
-const SectionBox = styled.div`
-  margin-bottom: ${props => props.theme.space[8]};
-`;
-
-const SectionTitleHeader = styled.h2`
-  font-family: ${props => props.theme.fontFamily.monospace};
-  font-size: ${props => props.theme.size['xl']};
-`;
-
-const SectionInner = styled.div`
-  margin-left: ${props => props.theme.space[2]};
-`;
-
 export const Section = (props: {title: string; children?: React.ReactNode}) => (
-  <SectionBox>
-    <SectionTitleHeader>{props.title}</SectionTitleHeader>
-    <SectionInner>{props.children}</SectionInner>
-  </SectionBox>
+  <div className={styles.sectionBox}>
+    <h2 className={styles.sectionTitleHeader}>{props.title}</h2>
+    <div className={styles.sectionInner}>{props.children}</div>
+  </div>
 );
 
-export const TextList = styled.ul`
-  font-size: ${props => props.theme.size.sm};
-  margin-bottom: ${props => props.theme.space[4]};
-  li {
-    margin-bottom: ${props => props.theme.space[2]};
-  }
-  code {
-    font-size: ${props => props.theme.size.xs};
-    font-family: ${props => props.theme.fontFamily.monospace};
-    background-color: ${props => props.theme.color.codeBg};
-  }
-`;
+export const TextList = (props: {children?: React.ReactNode}) => (
+  <ul className={styles.textList}>{props.children}</ul>
+);
 
-export const Box = styled.div`
-  display: flex;
-  flex-flow: column wrap;
-`;
+export const Box = (props: {children?: React.ReactNode}) => (
+  <div className={styles.box}>{props.children}</div>
+);
 
-export const Item = styled.div<{$grow?: number}>`
-  display: flex;
-  flex-grow: ${props => props.$grow || 0};
-`;
+export const Item = (props: {
+  $grow?: number;
+  style?: React.CSSProperties;
+  children?: React.ReactNode;
+}) => (
+  <div
+    className={styles.item}
+    style={
+      {
+        ...props.style,
+        '--item-grow': props.$grow ?? 0,
+      } as React.CSSProperties
+    }
+  >
+    {props.children}
+  </div>
+);
 
-export const Row = styled.div`
-  display: flex;
-  flex-flow: row wrap;
-  ${Item} + ${Item} {
-    margin-left: ${props => props.theme.space[4]};
-  }
-`;
+// Replaces styled-components' `${Item} + ${Item}` component selector with a
+// `gap` on the flex row (see Parts.module.css .row) — no CSS Modules
+// equivalent exists for generated-class adjacency selectors.
+export const Row = (props: {children?: React.ReactNode}) => (
+  <div className={styles.row}>{props.children}</div>
+);
 
-export const DividerH = styled.div`
-  margin: ${props => props.theme.space[4]} 0;
-  height: ${props => props.theme.space[1]};
-  background: linear-gradient(
-    90deg,
-    transparent 20%,
-    ${props => props.theme.color.lightgray} 20%,
-    ${props => props.theme.color.lightgray} 80%,
-    transparent 80%
-  );
-`;
+export const DividerH = () => <div className={styles.dividerH} />;
 
-export const DividerV = styled.div`
-  margin: 0 ${props => props.theme.space[2]};
-  width: ${props => props.theme.space[1]};
-  height: 100%;
-  background: linear-gradient(
-    180deg,
-    transparent 20%,
-    ${props => props.theme.color.lightgray} 20%,
-    ${props => props.theme.color.lightgray} 80%,
-    transparent 80%
-  );
-`;
+export const DividerV = () => <div className={styles.dividerV} />;
 
 export const ExternalLink = (props: {
   href: string;
@@ -121,11 +78,7 @@ export const ExternalLink = (props: {
   );
 };
 
-const Center = styled.div`
-  text-align: center;
-`;
-
 export const VersionLabel = () => {
   const label = useMemo(() => chrome.runtime.getManifest()?.version_name, []);
-  return <Center>{label}</Center>;
+  return <div className={styles.center}>{label}</div>;
 };

--- a/src/components/options/Parts.tsx
+++ b/src/components/options/Parts.tsx
@@ -17,6 +17,8 @@ export const Title = memo(() => {
       <Link to="/">
         <div
           className={[styles.titleIcon, dev ? styles.dev : ''].join(' ').trim()}
+          role="img"
+          aria-label="cocopy"
         />
       </Link>
     </header>

--- a/src/components/popup/App.tsx
+++ b/src/components/popup/App.tsx
@@ -1,15 +1,11 @@
-import React from 'react';
-import {ThemeProvider} from 'styled-components';
-
-import {theme} from '../common/Theme';
 import {FunctionList} from './FunctionList';
 import {PopupHeader} from './Header';
 
 export const App = () => {
   return (
-    <ThemeProvider theme={theme}>
+    <>
       <PopupHeader />
       <FunctionList />
-    </ThemeProvider>
+    </>
   );
 };

--- a/src/components/popup/Error.module.css
+++ b/src/components/popup/Error.module.css
@@ -1,0 +1,5 @@
+.functionErrorBox {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}

--- a/src/components/popup/Error.tsx
+++ b/src/components/popup/Error.tsx
@@ -1,17 +1,11 @@
-import styled from 'styled-components';
-
 import {EvalError} from '../../lib/eval';
 
-const FunctionErrorBox = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-`;
+import styles from './Error.module.css';
 
 export function FunctionError(props: {error: EvalError}) {
   return (
-    <FunctionErrorBox>
+    <div className={styles.functionErrorBox}>
       {props.error.name}: {props.error.message}
-    </FunctionErrorBox>
+    </div>
   );
 }

--- a/src/components/popup/Function.module.css
+++ b/src/components/popup/Function.module.css
@@ -1,0 +1,37 @@
+@keyframes scanning {
+  0% {
+    background-position: 100%;
+  }
+  50% {
+    background-position: 50%;
+  }
+  100% {
+    background-position: 0%;
+  }
+}
+
+.running {
+  animation-name: scanning;
+  animation-duration: 0.3s;
+  animation-timing-function: linear;
+  animation-iteration-count: 1;
+  background-size: 300% 100%;
+  background-position: 0%;
+  background-image: linear-gradient(
+    90deg,
+    var(--background-color) 0%,
+    var(--background-color) 35%,
+    var(--text-color) 60%,
+    var(--background-color) 60%,
+    var(--background-color) 100%
+  );
+}
+
+/* XXX sometime scanning animation stops accidentally.
+   GPU & CSS animation problem? I met this when using this ext on sub display. */
+.idle {
+  animation-name: none !important;
+  background-color: var(--background-color);
+  background-image: none;
+  background-position: 0% !important;
+}

--- a/src/components/popup/Function.tsx
+++ b/src/components/popup/Function.tsx
@@ -1,5 +1,4 @@
 import {useCallback, useMemo} from 'react';
-import styled, {css, keyframes} from 'styled-components';
 
 import {EvalError} from '../../lib/eval';
 import {CopyFunction} from '../../lib/function';
@@ -7,56 +6,19 @@ import {indexToKey} from '../../lib/util';
 import {
   Shortcut,
   FunctionBox,
-  FunctionBoxProps,
   FunctionName,
   RigthIconBox,
 } from '../common/FunctionParts';
 import {PatternIcon} from '../common/Icon';
 import {FunctionError} from './Error';
 
+import styles from './Function.module.css';
+
 function wrapKeyDown(cb: () => void) {
   return (e: KeyboardEvent) => {
     if (e.key === 'Enter' || e.key === ' ') cb();
   };
 }
-
-const scanning = keyframes`
-  0% { background-position: 100% }
-  50% { background-position: 50% }
-  100% { background-position: 0% }
-`;
-
-const execAnimation = css<FunctionBoxProps>`
-  animation-name: ${scanning};
-  animation-duration: 0.3s;
-  animation-timing-function: linear;
-  animation-iteration-count: 1;
-  background-size: 300% 100%;
-  background-position: 0%;
-  background-image: linear-gradient(
-    90deg,
-    ${p => p.$backgroundColor} 0%,
-    ${p => p.$backgroundColor} 35%,
-    ${p => p.$textColor} 60%,
-    ${p => p.$backgroundColor} 60%,
-    ${p => p.$backgroundColor} 100%
-  );
-`;
-
-// XXX sometime scanning animation stops accidentally.
-// GPU & CSS animation problem? I met this when using this ext on sub display.
-const cancelAnimation = css<FunctionBoxProps>`
-  animation-name: none !important;
-  background-color: ${p => p.$backgroundColor};
-  background-image: none;
-  background-position: 0% !important;
-`;
-
-const FunctionBoxWithAnimation = styled(FunctionBox)<
-  FunctionBoxProps & {$running: boolean}
->`
-  ${p => (p.$running ? execAnimation : cancelAnimation)};
-`;
 
 type FunctionItemProps = {
   fn: CopyFunction;
@@ -73,11 +35,11 @@ export function FunctionItem(props: FunctionItemProps) {
   const onKeyDown = useCallback(wrapKeyDown(onClick), [onClick]);
 
   return (
-    <FunctionBoxWithAnimation
+    <FunctionBox
+      className={running ? styles.running : styles.idle}
       $textColor={fn.theme.textColor}
       $backgroundColor={fn.theme.backgroundColor}
       onClick={onClick}
-      $running={running}
       onKeyDown={onKeyDown as any}
       tabIndex={1}
     >
@@ -94,6 +56,6 @@ export function FunctionItem(props: FunctionItemProps) {
           <PatternIcon />
         </RigthIconBox>
       )}
-    </FunctionBoxWithAnimation>
+    </FunctionBox>
   );
 }

--- a/src/components/popup/Header.module.css
+++ b/src/components/popup/Header.module.css
@@ -33,7 +33,7 @@
   right: 0;
   font-size: var(--size-xl);
   margin-right: var(--space-4);
-  color: #666;
+  color: var(--color-gray);
 }
 .optionLink:hover,
 .optionLink:focus {

--- a/src/components/popup/Header.module.css
+++ b/src/components/popup/Header.module.css
@@ -1,0 +1,42 @@
+.headerBox {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+}
+
+.title {
+  width: 84px;
+  height: 40px;
+  background: no-repeat center/contain url('../../img/logo.png');
+  margin: var(--space-1);
+  padding: 0 var(--space-1);
+  filter: none;
+}
+.title.dev {
+  filter: invert(24%) sepia(85%) saturate(3947%) hue-rotate(167deg)
+    brightness(93%) contrast(101%);
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.optionLink {
+  position: absolute;
+  right: 0;
+  font-size: var(--size-xl);
+  margin-right: var(--space-4);
+  color: #666;
+}
+.optionLink:hover,
+.optionLink:focus {
+  color: #333;
+  animation: spin 1.5s linear infinite;
+}

--- a/src/components/popup/Header.tsx
+++ b/src/components/popup/Header.tsx
@@ -1,60 +1,19 @@
 import {faCog} from '@fortawesome/free-solid-svg-icons/faCog';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {useMemo} from 'react';
-import styled, {keyframes} from 'styled-components';
 
 import {isDev} from '../../lib/util';
 
-const HeaderBox = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  position: relative;
-`;
-
-const Title = styled.div<{$dev: boolean}>`
-  width: 84px;
-  height: 40px;
-  background: no-repeat center/contain url('img/logo.png');
-  margin: ${props => props.theme.space[1]};
-  padding: 0 ${props => props.theme.space[1]};
-  filter: ${props =>
-    props.$dev
-      ? 'invert(24%) sepia(85%) saturate(3947%) hue-rotate(167deg) brightness(93%) contrast(101%)'
-      : 'none'};
-`;
-
-const spin = keyframes`
-  0% {
-    transform: rotate(0deg);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
-`;
-
-const OptionLink = styled.a`
-  position: absolute;
-  right: 0;
-  font-size: ${props => props.theme.size.xl};
-  margin-right: ${props => props.theme.space[4]};
-  color: #666;
-  &:hover,
-  &:focus {
-    color: #333;
-    animation: ${spin} 1.5s linear infinite;
-  }
-`;
+import styles from './Header.module.css';
 
 export function PopupHeader() {
   const dev = useMemo(() => isDev(), []);
   return (
-    <HeaderBox>
-      <Title $dev={dev} />
-      <OptionLink href="/options.html" target="_blank">
+    <div className={styles.headerBox}>
+      <div className={[styles.title, dev ? styles.dev : ''].join(' ').trim()} />
+      <a className={styles.optionLink} href="/options.html" target="_blank">
         <FontAwesomeIcon icon={faCog} />
-      </OptionLink>
-    </HeaderBox>
+      </a>
+    </div>
   );
 }

--- a/src/components/popup/Header.tsx
+++ b/src/components/popup/Header.tsx
@@ -10,8 +10,17 @@ export function PopupHeader() {
   const dev = useMemo(() => isDev(), []);
   return (
     <div className={styles.headerBox}>
-      <div className={[styles.title, dev ? styles.dev : ''].join(' ').trim()} />
-      <a className={styles.optionLink} href="/options.html" target="_blank">
+      <div
+        className={[styles.title, dev ? styles.dev : ''].join(' ').trim()}
+        role="img"
+        aria-label="cocopy"
+      />
+      <a
+        className={styles.optionLink}
+        href="/options.html"
+        target="_blank"
+        aria-label="Settings"
+      >
         <FontAwesomeIcon icon={faCog} />
       </a>
     </div>

--- a/src/libs.d.ts
+++ b/src/libs.d.ts
@@ -1,5 +1,12 @@
 declare module '*.css';
 
+// CSS Modules trial (see NEXT_PLAN.md Phase 2 styled-components migration).
+// Vite handles *.module.css natively; this just gives TS the class-name map shape.
+declare module '*.module.css' {
+  const classes: {readonly [key: string]: string};
+  export default classes;
+}
+
 declare module 'prismjs/components/prism-core' {
   export function highlight(code: any, language: any): any;
 

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -4,6 +4,7 @@ import {HashRouter as Router} from 'react-router-dom';
 
 import {App} from './components/options/App';
 
+import './theme.css';
 import './components/options/prism.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -2,4 +2,6 @@ import * as ReactDOM from 'react-dom/client';
 
 import {App} from './components/popup/App';
 
+import './theme.css';
+
 ReactDOM.createRoot(document.getElementById('root')!).render(<App />);

--- a/src/styled.d.ts
+++ b/src/styled.d.ts
@@ -1,5 +1,0 @@
-import type {Theme} from './components/common/Theme';
-
-declare module 'styled-components' {
-  interface DefaultTheme extends Theme {}
-}

--- a/src/theme.css
+++ b/src/theme.css
@@ -1,0 +1,58 @@
+/* Global CSS custom properties mirroring src/components/common/Theme.ts.
+   Naming is mechanical: --space-<n>, --size-<name>, --font-<weight-name>,
+   --color-<name>, --font-monospace / --font-default, --constants-<name>.
+   Imported once from each entry point (popup.tsx / options.tsx), same
+   pattern as the existing code.css / prism.css imports. */
+:root {
+  /* space */
+  --space-0: 0;
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-10: 2.5rem;
+
+  /* size */
+  --size-xs: 0.75rem;
+  --size-sm: 0.875rem;
+  --size-base: 1rem;
+  --size-lg: 1.125rem;
+  --size-xl: 1.25rem;
+  --size-2xl: 1.5rem;
+  --size-3xl: 1.875rem;
+  --size-4xl: 2.25rem;
+  --size-5xl: 3rem;
+  --size-6xl: 4rem;
+
+  /* font weight */
+  --font-hairline: 100;
+  --font-thin: 200;
+  --font-light: 300;
+  --font-normal: 400;
+  --font-medium: 500;
+  --font-semibold: 600;
+  --font-bold: 700;
+  --font-extrabold: 800;
+  --font-black: 900;
+
+  /* color */
+  --color-gray: #666;
+  --color-lightgray: #ddd;
+  --color-codeBg: #f5f2f0;
+  --color-error: #f44336;
+  --color-danger: #f44336;
+  --color-warning: #4338ca;
+  --color-primary: #007bff;
+
+  /* font family */
+  --font-default: inherit;
+  --font-monospace:
+    Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+
+  /* constants */
+  --constants-functionWidth: 380px;
+  --constants-functionHeight: 32px;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,8 +13,6 @@ const srcDir = path.join(rootDir, 'src');
 // LICENSE file. Mirrors licenseTextOverrides from the previous
 // license-webpack-plugin config.
 const licenseTextOverrides: Record<string, string> = {
-  'styled-components':
-    'https://github.com/styled-components/styled-components/blob/master/LICENSE',
   isarray: 'https://github.com/juliangruber/isarray/blob/master/LICENSE',
   '@react-dnd/invariant':
     'https://github.com/react-dnd/react-dnd/blob/main/LICENSE',


### PR DESCRIPTION
## What

Phase 2 of the modernization plan (NEXT_PLAN.md): replace styled-components (maintenance mode) with CSS Modules across the entire UI, in two commits:

1. **Trial** (`5a3e8a7`): converted the hardest case first — popup's Function components with per-function dynamic theme colors and a keyframes animation inherited via `styled(FunctionBox)` — to validate the approach and decide between CSS Modules and vanilla-extract
2. **Full migration** (`f50964d`): converted everything else (popup Header/App, all options components), removed ThemeProvider and the styled-components dependency entirely

## Why CSS Modules (not vanilla-extract)

The decisive finding from the trial: per-function dynamic theme colors collapse to the same CSS-custom-property mechanism in both approaches (`style={{'--text-color': ...}}` → `var(--text-color)`; vanilla-extract would need `@vanilla-extract/dynamic` for the same thing). With no complexity win on the hardest requirement, CSS Modules wins on the project's consistent "thin, easy to exit" bias: native Vite support, zero added dependencies. Details in the decision record in NEXT_PLAN.md.

## Design notes

- `src/theme.css` enumerates the `theme.ts` values as `:root` custom properties with mechanical naming (`--space-*`, `--size-*`, `--color-*`, `--font-*`, `--constants-*`), imported once per entry. Runtime-dynamic values (per-function colors) are component-local inline custom properties — the same two-layer structure the styled-components theme + props setup had
- `styled(X)` inheritance became className concatenation. One regression from this pattern was caught in visual review (DragKnob lost ItemButton's flex centering) and fixed by keeping both classes
- The only non-mechanical selector, `${Item} + ${Item}` adjacency in options/Parts.tsx, became `gap` on the flex row (verified visually equivalent for all usages)
- `Theme.tsx` survives only for `options/CodeEditor.tsx`, which passes theme values as TS props to react-simple-code-editor rather than via CSS

## Verification

- `pnpm test` (22 Vitest + oxlint / oxfmt / tsc) and `pnpm e2e` (4/4, including the popup function-button animation path and options drag & drop reorder) green
- Manual visual check of both popup (function buttons, theme colors, scanning animation, error display) and options (list rows, drag knob, add row, forms, logo)
- Net -214 lines