### PR TITLE
chore: run E2E tests in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,4 +18,6 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
       - run: pnpm run build
+      - run: pnpm exec playwright install --with-deps chromium
+      - run: pnpm run e2e
       - run: pnpm run update-gallery


### PR DESCRIPTION
## Summary

- Install Playwright Chromium in the existing test workflow.
- Run the Playwright E2E suite after the extension build.

## Validation

- `pnpm test` (39 tests passed)
- `pnpm run build`
- `pnpm run e2e` (9 tests passed locally)
