### PR TITLE
Improve completion keybindings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,4 +18,6 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
       - run: pnpm run build
+      - run: pnpm exec playwright install --with-deps chromium
+      - run: pnpm run e2e
       - run: pnpm run update-gallery

--- a/src/components/options/CodeEditor.tsx
+++ b/src/components/options/CodeEditor.tsx
@@ -4,6 +4,7 @@ import {useCallback} from 'react';
 
 import {theme} from '../common/Theme';
 import {
+  additionalCompletionKeymap,
   cocopyCompletionSource,
   javascriptCompletionSource,
 } from './completions';
@@ -14,6 +15,7 @@ import './code.css';
 const editorId = 'code';
 
 const editorExtensions = [
+  additionalCompletionKeymap,
   javascript(),
   javascriptLanguage.data.of({autocomplete: cocopyCompletionSource}),
   javascriptLanguage.data.of({

--- a/src/components/options/completions.test.ts
+++ b/src/components/options/completions.test.ts
@@ -1,13 +1,22 @@
 import {
   autocompletion,
+  closeCompletion,
   CompletionContext,
   currentCompletions,
+  selectedCompletionIndex,
   startCompletion,
 } from '@codemirror/autocomplete';
 import {javascript, javascriptLanguage} from '@codemirror/lang-javascript';
-import {EditorState, EditorView, Transaction} from '@uiw/react-codemirror';
+import {
+  EditorState,
+  EditorView,
+  keymap,
+  runScopeHandlers,
+  Transaction,
+} from '@uiw/react-codemirror';
 
 import {
+  additionalCompletionKeymap,
   cocopyCompletionSource,
   javascriptCompletionSource,
 } from './completions';
@@ -135,6 +144,7 @@ test('registers destructuring completions with the editor', async () => {
       doc: code,
       selection: {anchor: code.indexOf('ti') + 2},
       extensions: [
+        additionalCompletionKeymap,
         javascript(),
         javascriptLanguage.data.of({autocomplete: cocopyCompletionSource}),
         javascriptLanguage.data.of({autocomplete: javascriptCompletionSource}),
@@ -144,11 +154,17 @@ test('registers destructuring completions with the editor', async () => {
   });
 
   startCompletion(view);
-  await new Promise(resolve => setTimeout(resolve, 100));
+  await new Promise(resolve => setTimeout(resolve, 200));
 
   expect(currentCompletions(view.state).map(option => option.label)).toContain(
     'title',
   );
+  expect(
+    view.state
+      .facet(keymap)
+      .flat()
+      .map(binding => binding.key),
+  ).toContain('Tab');
   view.destroy();
 });
 
@@ -159,6 +175,7 @@ test('activates destructuring completions while typing', async () => {
       doc: '({',
       selection: {anchor: 2},
       extensions: [
+        additionalCompletionKeymap,
         javascript(),
         javascriptLanguage.data.of({autocomplete: cocopyCompletionSource}),
         javascriptLanguage.data.of({autocomplete: javascriptCompletionSource}),
@@ -177,5 +194,122 @@ test('activates destructuring completions while typing', async () => {
   expect(currentCompletions(view.state).map(option => option.label)).toContain(
     'title',
   );
+  view.destroy();
+});
+
+test('accepts the selected completion with Tab', async () => {
+  const code = '({ti';
+  const view = new EditorView({
+    parent: document.body,
+    state: EditorState.create({
+      doc: code,
+      selection: {anchor: code.length},
+      extensions: [
+        additionalCompletionKeymap,
+        javascript(),
+        javascriptLanguage.data.of({autocomplete: cocopyCompletionSource}),
+        javascriptLanguage.data.of({autocomplete: javascriptCompletionSource}),
+        autocompletion(),
+      ],
+    }),
+  });
+
+  startCompletion(view);
+  await new Promise(resolve => setTimeout(resolve, 200));
+  expect(currentCompletions(view.state).map(option => option.label)).toContain(
+    'title',
+  );
+  expect(
+    runScopeHandlers(
+      view,
+      new KeyboardEvent('keydown', {key: 'Tab', code: 'Tab'}),
+      'editor',
+    ),
+  ).toBe(true);
+
+  expect(view.state.doc.toString()).toBe('({title');
+  view.destroy();
+});
+
+test('uses Ctrl-N and Ctrl-P to move through completions', async () => {
+  const code = '({}) => {}';
+  const view = new EditorView({
+    parent: document.body,
+    state: EditorState.create({
+      doc: code,
+      selection: {anchor: code.indexOf('}')},
+      extensions: [
+        additionalCompletionKeymap,
+        javascript(),
+        javascriptLanguage.data.of({autocomplete: cocopyCompletionSource}),
+        javascriptLanguage.data.of({autocomplete: javascriptCompletionSource}),
+        autocompletion(),
+      ],
+    }),
+  });
+
+  startCompletion(view);
+  await new Promise(resolve => setTimeout(resolve, 200));
+
+  expect(currentCompletions(view.state).length).toBeGreaterThan(1);
+  expect(selectedCompletionIndex(view.state)).toBe(0);
+  runScopeHandlers(
+    view,
+    new KeyboardEvent('keydown', {
+      key: 'n',
+      code: 'KeyN',
+      ctrlKey: true,
+    }),
+    'editor',
+  );
+  expect(selectedCompletionIndex(view.state)).toBe(1);
+
+  runScopeHandlers(
+    view,
+    new KeyboardEvent('keydown', {
+      key: 'p',
+      code: 'KeyP',
+      ctrlKey: true,
+    }),
+    'editor',
+  );
+  expect(selectedCompletionIndex(view.state)).toBe(0);
+  view.destroy();
+});
+
+test('closes completions with Ctrl-G', async () => {
+  const code = '({}) => {}';
+  const view = new EditorView({
+    parent: document.body,
+    state: EditorState.create({
+      doc: code,
+      selection: {anchor: code.indexOf('}')},
+      extensions: [
+        additionalCompletionKeymap,
+        javascript(),
+        javascriptLanguage.data.of({autocomplete: cocopyCompletionSource}),
+        javascriptLanguage.data.of({autocomplete: javascriptCompletionSource}),
+        autocompletion(),
+      ],
+    }),
+  });
+
+  startCompletion(view);
+  await new Promise(resolve => setTimeout(resolve, 200));
+  expect(currentCompletions(view.state).length).toBeGreaterThan(1);
+
+  expect(
+    runScopeHandlers(
+      view,
+      new KeyboardEvent('keydown', {
+        key: 'g',
+        code: 'KeyG',
+        ctrlKey: true,
+      }),
+      'editor',
+    ),
+  ).toBe(true);
+  expect(currentCompletions(view.state)).toEqual([]);
+  expect(closeCompletion(view)).toBe(false);
   view.destroy();
 });

--- a/src/components/options/completions.test.ts
+++ b/src/components/options/completions.test.ts
@@ -54,6 +54,20 @@ function javascriptLabels(
     : result.options.map(option => option.label);
 }
 
+const testAutocompletion = autocompletion({
+  activateOnTypingDelay: 0,
+  interactionDelay: 0,
+});
+
+async function waitForCompletions(view: EditorView, min = 1) {
+  await vi.waitFor(
+    () => {
+      expect(currentCompletions(view.state).length).toBeGreaterThanOrEqual(min);
+    },
+    {timeout: 1000, interval: 10},
+  );
+}
+
 test('completes properties on the function argument', () => {
   expect(labels('(input) => input.')).toEqual([
     'title',
@@ -148,13 +162,13 @@ test('registers destructuring completions with the editor', async () => {
         javascript(),
         javascriptLanguage.data.of({autocomplete: cocopyCompletionSource}),
         javascriptLanguage.data.of({autocomplete: javascriptCompletionSource}),
-        autocompletion(),
+        testAutocompletion,
       ],
     }),
   });
 
   startCompletion(view);
-  await new Promise(resolve => setTimeout(resolve, 200));
+  await waitForCompletions(view);
 
   expect(currentCompletions(view.state).map(option => option.label)).toContain(
     'title',
@@ -179,7 +193,7 @@ test('activates destructuring completions while typing', async () => {
         javascript(),
         javascriptLanguage.data.of({autocomplete: cocopyCompletionSource}),
         javascriptLanguage.data.of({autocomplete: javascriptCompletionSource}),
-        autocompletion(),
+        testAutocompletion,
       ],
     }),
   });
@@ -189,7 +203,7 @@ test('activates destructuring completions while typing', async () => {
     selection: {anchor: 3},
     annotations: Transaction.userEvent.of('input.type'),
   });
-  await new Promise(resolve => setTimeout(resolve, 150));
+  await waitForCompletions(view);
 
   expect(currentCompletions(view.state).map(option => option.label)).toContain(
     'title',
@@ -209,13 +223,13 @@ test('accepts the selected completion with Tab', async () => {
         javascript(),
         javascriptLanguage.data.of({autocomplete: cocopyCompletionSource}),
         javascriptLanguage.data.of({autocomplete: javascriptCompletionSource}),
-        autocompletion(),
+        testAutocompletion,
       ],
     }),
   });
 
   startCompletion(view);
-  await new Promise(resolve => setTimeout(resolve, 200));
+  await waitForCompletions(view);
   expect(currentCompletions(view.state).map(option => option.label)).toContain(
     'title',
   );
@@ -243,13 +257,13 @@ test('uses Ctrl-N and Ctrl-P to move through completions', async () => {
         javascript(),
         javascriptLanguage.data.of({autocomplete: cocopyCompletionSource}),
         javascriptLanguage.data.of({autocomplete: javascriptCompletionSource}),
-        autocompletion(),
+        testAutocompletion,
       ],
     }),
   });
 
   startCompletion(view);
-  await new Promise(resolve => setTimeout(resolve, 200));
+  await waitForCompletions(view, 2);
 
   expect(currentCompletions(view.state).length).toBeGreaterThan(1);
   expect(selectedCompletionIndex(view.state)).toBe(0);
@@ -289,13 +303,13 @@ test('closes completions with Ctrl-G', async () => {
         javascript(),
         javascriptLanguage.data.of({autocomplete: cocopyCompletionSource}),
         javascriptLanguage.data.of({autocomplete: javascriptCompletionSource}),
-        autocompletion(),
+        testAutocompletion,
       ],
     }),
   });
 
   startCompletion(view);
-  await new Promise(resolve => setTimeout(resolve, 200));
+  await waitForCompletions(view, 2);
   expect(currentCompletions(view.state).length).toBeGreaterThan(1);
 
   expect(
@@ -324,7 +338,7 @@ test('blurs the editor with Escape when no completion is open', () => {
         javascript(),
         javascriptLanguage.data.of({autocomplete: cocopyCompletionSource}),
         javascriptLanguage.data.of({autocomplete: javascriptCompletionSource}),
-        autocompletion(),
+        testAutocompletion,
       ],
     }),
   });

--- a/src/components/options/completions.test.ts
+++ b/src/components/options/completions.test.ts
@@ -313,3 +313,31 @@ test('closes completions with Ctrl-G', async () => {
   expect(closeCompletion(view)).toBe(false);
   view.destroy();
 });
+
+test('blurs the editor with Escape when no completion is open', () => {
+  const view = new EditorView({
+    parent: document.body,
+    state: EditorState.create({
+      doc: '() => {}',
+      extensions: [
+        additionalCompletionKeymap,
+        javascript(),
+        javascriptLanguage.data.of({autocomplete: cocopyCompletionSource}),
+        javascriptLanguage.data.of({autocomplete: javascriptCompletionSource}),
+        autocompletion(),
+      ],
+    }),
+  });
+  const blur = vi.spyOn(view.contentDOM, 'blur');
+  view.focus();
+
+  expect(
+    runScopeHandlers(
+      view,
+      new KeyboardEvent('keydown', {key: 'Escape', code: 'Escape'}),
+      'editor',
+    ),
+  ).toBe(true);
+  expect(blur).toHaveBeenCalledOnce();
+  view.destroy();
+});

--- a/src/components/options/completions.ts
+++ b/src/components/options/completions.ts
@@ -11,7 +11,14 @@ import {
   scopeCompletionSource,
 } from '@codemirror/lang-javascript';
 import {syntaxTree} from '@codemirror/language';
-import {Prec, keymap} from '@uiw/react-codemirror';
+import {Prec, keymap, type EditorView} from '@uiw/react-codemirror';
+
+function closeCompletionOrBlur(view: EditorView): boolean {
+  if (closeCompletion(view)) return true;
+
+  view.contentDOM.blur();
+  return true;
+}
 
 export const additionalCompletionKeymap = Prec.highest(
   keymap.of([
@@ -19,6 +26,7 @@ export const additionalCompletionKeymap = Prec.highest(
     {key: 'Ctrl-n', run: moveCompletionSelection(true)},
     {key: 'Ctrl-p', run: moveCompletionSelection(false)},
     {key: 'Ctrl-g', run: closeCompletion},
+    {key: 'Escape', run: closeCompletionOrBlur},
   ]),
 );
 

--- a/src/components/options/completions.ts
+++ b/src/components/options/completions.ts
@@ -1,13 +1,26 @@
 import {
+  acceptCompletion,
+  closeCompletion,
   type Completion,
   type CompletionContext,
   type CompletionResult,
+  moveCompletionSelection,
 } from '@codemirror/autocomplete';
 import {
   completionPath,
   scopeCompletionSource,
 } from '@codemirror/lang-javascript';
 import {syntaxTree} from '@codemirror/language';
+import {Prec, keymap} from '@uiw/react-codemirror';
+
+export const additionalCompletionKeymap = Prec.highest(
+  keymap.of([
+    {key: 'Tab', run: acceptCompletion},
+    {key: 'Ctrl-n', run: moveCompletionSelection(true)},
+    {key: 'Ctrl-p', run: moveCompletionSelection(false)},
+    {key: 'Ctrl-g', run: closeCompletion},
+  ]),
+);
 
 const pageCompletions: readonly Completion[] = [
   {


### PR DESCRIPTION
## Summary

- Add Tab to accept the selected completion.
- Add Ctrl-N/Ctrl-P to move through completion candidates.
- Add Ctrl-G as an Emacs/Readline-style completion cancel key.
- Run the Playwright E2E suite in GitHub Actions.

## Validation

- pnpm test
- pnpm run build
