### PR TITLE
feat: add closeAfterCopy setting to close popup after copy

### DIFF
--- a/e2e/migration.spec.ts
+++ b/e2e/migration.spec.ts
@@ -57,7 +57,7 @@ async function openOptionsWithLegacy(
 }
 
 /**
- * Opens the "Legacy storage backup" page and returns its section. The backup
+ * Opens the "Legacy Functions" page and returns its section. The backup
  * lives on its own `/legacy` route, so the options root only carries a banner
  * linking to it; asserting on the root page finds the banner text but none of
  * the controls.
@@ -70,7 +70,7 @@ async function openLegacySection(page: import('@playwright/test').Page) {
   await page.goto(`${page.url().split('#')[0]}#/legacy`);
   const section = page
     .locator('div')
-    .filter({has: page.getByRole('heading', {name: 'Legacy storage backup'})})
+    .filter({has: page.getByRole('heading', {name: 'Legacy Functions'})})
     .last();
   await expect(section).toBeVisible();
   return section;
@@ -118,7 +118,7 @@ test('opening options migrates legacy data, preserving content and order', async
   // ...and the legacy sync key itself is left exactly as it was.
   expect(await readLegacyFunctions(options)).toEqual(legacyThree);
 
-  // The Legacy storage backup section reports the completed migration.
+  // The Legacy Functions section reports the completed migration.
   await options.reload();
   const section = await openLegacySection(options);
   await expect(section.getByText('migrated', {exact: false})).toBeVisible();
@@ -326,6 +326,6 @@ test('seeds the default functions when there is no legacy data', async ({
 
   // Nothing to recover, so the temporary backup section stays hidden.
   await expect(
-    options.getByRole('heading', {name: 'Legacy storage backup'}),
+    options.getByRole('heading', {name: 'Legacy Functions'}),
   ).toHaveCount(0);
 });

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@fortawesome/react-fontawesome": "3.5.0",
     "@uiw/react-codemirror": "4.25.11",
     "chroma-js": "3.2.0",
-    "jsx-runtime": "1.2.0",
     "lodash.debounce": "4.0.8",
     "mustache": "4.2.0",
     "react": "19.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,9 +38,6 @@ importers:
       chroma-js:
         specifier: 3.2.0
         version: 3.2.0
-      jsx-runtime:
-        specifier: 1.2.0
-        version: 1.2.0
       lodash.debounce:
         specifier: 4.0.8
         version: 4.0.8
@@ -1387,9 +1384,6 @@ packages:
       canvas:
         optional: true
 
-  jsx-runtime@1.2.0:
-    resolution: {integrity: sha512-iCxmRTlUAWmXwHZxN0JSx/T7eRi0SkKAskE0lp+j4W1mzdNp49ja/9QI2ZmlggPM95RqnDw5ioYjw0EcvpIClw==}
-
   lightningcss-android-arm64@1.33.0:
     resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
     engines: {node: '>= 12.0.0'}
@@ -1504,10 +1498,6 @@ packages:
     resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-
-  object-assign@3.0.0:
-    resolution: {integrity: sha512-jHP15vXVGeVh1HuaA2wY6lxk+whK/x4KBG88VXeRma7CCun7iGD5qPc4eYykQ9sdQvg8jkwFKsSxHln2ybW3xQ==}
-    engines: {node: '>=0.10.0'}
 
   obug@2.1.4:
     resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
@@ -2838,10 +2828,6 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
-  jsx-runtime@1.2.0:
-    dependencies:
-      object-assign: 3.0.0
-
   lightningcss-android-arm64@1.33.0:
     optional: true
 
@@ -2920,8 +2906,6 @@ snapshots:
   mustache@4.2.0: {}
 
   nanoid@3.3.16: {}
-
-  object-assign@3.0.0: {}
 
   obug@2.1.4: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+minimumReleaseAge: 10080
+trustPolicy: no-downgrade
+blockExoticSubdeps: true

--- a/src/components/common/ConfigContext.tsx
+++ b/src/components/common/ConfigContext.tsx
@@ -1,0 +1,14 @@
+import {createContext, useContext} from 'react';
+
+import {ConfigStore, getConfigStore} from '../../lib/config';
+
+// Default is undefined (not getConfigStore()) so that importing this module
+// never touches chrome.storage; tests wrap components in a provider carrying
+// a store built on InMemoryKeyValueStorage.
+const ConfigStoreContext = createContext<ConfigStore | undefined>(undefined);
+
+export const ConfigStoreProvider = ConfigStoreContext.Provider;
+
+export function useConfigStore(): ConfigStore {
+  return useContext(ConfigStoreContext) ?? getConfigStore();
+}

--- a/src/components/options/App.test.tsx
+++ b/src/components/options/App.test.tsx
@@ -114,7 +114,7 @@ test('render legacy page', async () => {
   render(renderWithStore(store, <App />, ['/legacy']));
 
   await waitFor(() =>
-    expect(screen.getByText('Legacy storage backup')).toBeInTheDocument(),
+    expect(screen.getByText('Legacy Functions')).toBeInTheDocument(),
   );
 
   // The full inspection UI renders on its own page, not the function list.

--- a/src/components/options/App.tsx
+++ b/src/components/options/App.tsx
@@ -11,11 +11,11 @@ import {Settings} from './Settings';
 const PageRoot = () => (
   <>
     <FunctionList />
-    <LegacyBackupBanner />
     <Settings />
     <Hint />
     <DebuggingHint />
     <Links />
+    <LegacyBackupBanner />
   </>
 );
 

--- a/src/components/options/App.tsx
+++ b/src/components/options/App.tsx
@@ -6,11 +6,13 @@ import {InstallFunction} from './InstallFunction';
 import {LegacyBackup, LegacyBackupBanner} from './LegacyBackup';
 import {Links} from './Links';
 import {MainColumn, Title, VersionLabel} from './Parts';
+import {Settings} from './Settings';
 
 const PageRoot = () => (
   <>
     <FunctionList />
     <LegacyBackupBanner />
+    <Settings />
     <Hint />
     <DebuggingHint />
     <Links />

--- a/src/components/options/ColorInput.module.css
+++ b/src/components/options/ColorInput.module.css
@@ -28,10 +28,15 @@
 
 .paletteColorBox {
   background-color: var(--palette-color);
+  appearance: none;
   width: var(--size-2xl);
   height: var(--size-2xl);
   margin: var(--space-1);
+  padding: 0;
+  border: 0;
   cursor: pointer;
+  color: inherit;
+  font: inherit;
 
   display: flex;
   justify-content: center;

--- a/src/components/options/ColorInput.tsx
+++ b/src/components/options/ColorInput.tsx
@@ -11,16 +11,19 @@ import styles from './ColorInput.module.css';
 
 const PaletteColorBox = (props: {
   $color: string;
+  ariaLabel: string;
   onClick: () => void;
   children?: React.ReactNode;
 }) => (
-  <div
+  <button
+    type="button"
+    aria-label={props.ariaLabel}
     className={styles.paletteColorBox}
     style={{'--palette-color': props.$color} as React.CSSProperties}
     onClick={props.onClick}
   >
     {props.children}
-  </div>
+  </button>
 );
 
 const PaletteColor = (props: {
@@ -31,7 +34,13 @@ const PaletteColor = (props: {
     () => props.onClick(props.color),
     [props.onClick, props.color],
   );
-  return <PaletteColorBox $color={props.color} onClick={onClick} />;
+  return (
+    <PaletteColorBox
+      $color={props.color}
+      ariaLabel={props.color}
+      onClick={onClick}
+    />
+  );
 };
 
 const PaletteColorRandom = (props: {onClick: (color: string) => void}) => {
@@ -40,7 +49,11 @@ const PaletteColorRandom = (props: {onClick: (color: string) => void}) => {
     [props.onClick],
   );
   return (
-    <PaletteColorBox $color="transparent" onClick={onClick}>
+    <PaletteColorBox
+      $color="transparent"
+      ariaLabel="Choose a random color"
+      onClick={onClick}
+    >
       <FontAwesomeIcon icon={faRandom} />
     </PaletteColorBox>
   );

--- a/src/components/options/FunctionList.module.css
+++ b/src/components/options/FunctionList.module.css
@@ -18,6 +18,11 @@
   justify-content: center;
   width: var(--size-4xl);
   height: var(--constants-functionHeight);
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
   cursor: pointer;
 }
 

--- a/src/components/options/FunctionList.tsx
+++ b/src/components/options/FunctionList.tsx
@@ -34,9 +34,15 @@ import styles from './FunctionList.module.css';
 export const Caret = (props: {active: boolean; onClick: () => void}) => {
   const {active, onClick} = props;
   return (
-    <div className={styles.itemButton} onClick={onClick}>
+    <button
+      type="button"
+      className={styles.itemButton}
+      onClick={onClick}
+      aria-label={active ? 'Collapse function' : 'Expand function'}
+      aria-expanded={active}
+    >
       <FontAwesomeIcon icon={active ? faCaretDown : faCaretRight} size="lg" />
-    </div>
+    </button>
   );
 };
 
@@ -65,9 +71,14 @@ export function EditorBox(props: {children?: React.ReactNode}) {
 function AddFunction(props: {onClick: () => void}) {
   return (
     <div className={styles.functionItemBox}>
-      <div className={styles.itemButton} onClick={props.onClick}>
+      <button
+        type="button"
+        className={styles.itemButton}
+        onClick={props.onClick}
+        aria-label="Create new function"
+      >
         <FontAwesomeIcon icon={faPlus} />
-      </div>
+      </button>
       <AddFunctionItem onClick={props.onClick} />
     </div>
   );

--- a/src/components/options/LegacyBackup.test.tsx
+++ b/src/components/options/LegacyBackup.test.tsx
@@ -82,7 +82,7 @@ test('renders nothing on a fresh install', async () => {
     await new Promise(resolve => setTimeout(resolve, 0));
   });
   expect(container).toBeEmptyDOMElement();
-  expect(screen.queryByText('Legacy storage backup')).not.toBeInTheDocument();
+  expect(screen.queryByText('Legacy Functions')).not.toBeInTheDocument();
 });
 
 test('renders nothing when migration only seeded the default functions', async () => {
@@ -113,7 +113,7 @@ test('deleting a migrated function re-enables its Import', async () => {
   });
 
   render(renderWithStore(store, <LegacyBackup />));
-  await screen.findByText('Legacy storage backup');
+  await screen.findByText('Legacy Functions');
 
   // Entries start collapsed; expand both to see their state.
   fireEvent.click(screen.getByText('name-a'));
@@ -141,7 +141,7 @@ test('expanding an entry shows its pattern and code without any way to save', as
   });
 
   render(renderWithStore(store, <LegacyBackup />));
-  await screen.findByText('Legacy storage backup');
+  await screen.findByText('Legacy Functions');
 
   fireEvent.click(screen.getByText('name-a'));
 
@@ -184,7 +184,7 @@ test('shows the entry list with a one-line summary and per-function state', asyn
 
   render(renderWithStore(store, <LegacyBackup />));
 
-  await screen.findByText('Legacy storage backup');
+  await screen.findByText('Legacy Functions');
 
   // Provenance is one line under the export button, not a per-store table.
   const bytes = new TextEncoder().encode(JSON.stringify(legacy)).length;
@@ -220,7 +220,7 @@ test('an entry missing from the catalog can be imported without touching the leg
   });
 
   render(renderWithStore(store, <LegacyBackup />));
-  await screen.findByText('Legacy storage backup');
+  await screen.findByText('Legacy Functions');
 
   fireEvent.click(screen.getByText('name-b'));
   expect(screen.getByText('Not migrated')).toBeInTheDocument();
@@ -271,7 +271,7 @@ test('an imported entry is still recognized after the page is reopened', async (
   });
 
   const first = render(renderWithStore(store, <LegacyBackup />));
-  await screen.findByText('Legacy storage backup');
+  await screen.findByText('Legacy Functions');
   fireEvent.click(screen.getByText('name-b'));
   fireEvent.click(screen.getByRole('button', {name: 'Import'}));
   await waitFor(async () => expect(await storedIds(store)).toEqual(['b']));
@@ -280,7 +280,7 @@ test('an imported entry is still recognized after the page is reopened', async (
   // Reopening the page rebuilds the row state from the catalog alone; the row
   // must not offer Import again, which would create a duplicate.
   render(renderWithStore(store, <LegacyBackup />));
-  await screen.findByText('Legacy storage backup');
+  await screen.findByText('Legacy Functions');
   fireEvent.click(screen.getByText('name-b'));
 
   expect(screen.getByText('Already in your functions')).toBeInTheDocument();
@@ -302,7 +302,7 @@ test('a function skipped for size cannot be imported as-is and links to the edit
   });
 
   render(renderWithStore(store, <LegacyBackup />));
-  await screen.findByText('Legacy storage backup');
+  await screen.findByText('Legacy Functions');
   fireEvent.click(screen.getByText('name-b'));
 
   // Import as-is would only hit the per-item limit again; recovery goes
@@ -330,7 +330,7 @@ test('a function that fails validation cannot be imported and links to the edito
   });
 
   render(renderWithStore(store, <LegacyBackup />));
-  await screen.findByText('Legacy storage backup');
+  await screen.findByText('Legacy Functions');
 
   fireEvent.click(screen.getByText('name-b'));
   expect(
@@ -360,7 +360,7 @@ test('a function with a broken shape still gets an editor link carrying what is 
   });
 
   render(renderWithStore(store, <LegacyBackup />));
-  await screen.findByText('Legacy storage backup');
+  await screen.findByText('Legacy Functions');
 
   fireEvent.click(screen.getByText('kept name'));
   expect(
@@ -391,7 +391,7 @@ test('deleting an entry removes it from both the backup and the legacy sync valu
   const confirm = vi.spyOn(window, 'confirm').mockReturnValue(true);
 
   render(renderWithStore(store, <LegacyBackup />));
-  await screen.findByText('Legacy storage backup');
+  await screen.findByText('Legacy Functions');
 
   fireEvent.click(screen.getByText('name-a'));
   fireEvent.click(screen.getByRole('button', {name: 'Delete'}));
@@ -430,7 +430,7 @@ test('cancelling the delete confirmation leaves the legacy data intact', async (
   vi.spyOn(window, 'confirm').mockReturnValue(false);
 
   render(renderWithStore(store, <LegacyBackup />));
-  await screen.findByText('Legacy storage backup');
+  await screen.findByText('Legacy Functions');
 
   fireEvent.click(screen.getByText('name-a'));
   fireEvent.click(screen.getByRole('button', {name: 'Delete'}));
@@ -462,7 +462,7 @@ test('a failed migration shows the error and can still export', async () => {
   vi.stubGlobal('URL', {...URL, createObjectURL, revokeObjectURL});
 
   render(renderWithStore(store, <LegacyBackup />));
-  await screen.findByText('Legacy storage backup');
+  await screen.findByText('Legacy Functions');
 
   expect(
     screen.getByText('migration failed', {exact: false}),
@@ -516,7 +516,7 @@ test('banner links to the legacy page without rendering the full section', async
   render(renderWithStore(store, <LegacyBackupBanner />));
 
   const link = await screen.findByRole('link', {
-    name: 'Legacy storage backup',
+    name: 'Legacy Functions',
   });
   expect(link.getAttribute('href')).toBe('/legacy');
   // The banner explains why legacy data exists before pointing at it, and
@@ -555,7 +555,7 @@ test('banner reports functions the migration left behind', async () => {
 
   render(renderWithStore(store, <LegacyBackupBanner />));
 
-  await screen.findByRole('link', {name: 'Legacy storage backup'});
+  await screen.findByRole('link', {name: 'Legacy Functions'});
   expect(
     screen.getByText('1 function(s) could not be carried over.', {
       exact: false,
@@ -572,7 +572,7 @@ test('banner reports a failed migration', async () => {
 
   render(renderWithStore(store, <LegacyBackupBanner />));
 
-  await screen.findByRole('link', {name: 'Legacy storage backup'});
+  await screen.findByRole('link', {name: 'Legacy Functions'});
   expect(
     screen.getByText(
       'The automatic migration failed. Your original data is kept untouched',
@@ -595,7 +595,7 @@ test('a renamed id counts as already migrated', async () => {
   });
 
   render(renderWithStore(store, <LegacyBackup />));
-  await screen.findByText('Legacy storage backup');
+  await screen.findByText('Legacy Functions');
 
   fireEvent.click(screen.getByText('name-dup'));
   fireEvent.click(screen.getByText('name-dup2'));

--- a/src/components/options/LegacyBackup.tsx
+++ b/src/components/options/LegacyBackup.tsx
@@ -345,9 +345,15 @@ function EntryRow(props: {
       <div className={listStyles.functionItemBox}>
         <Caret active={expanded} onClick={toggle} />
         <FunctionItem fn={entry.fn} onClick={toggle} />
-        <div
+        <button
+          type="button"
           className={[listStyles.itemButton, styles.stateIconBox].join(' ')}
           onClick={toggle}
+          aria-label={
+            done
+              ? 'Show function details'
+              : 'Show migration warning and function details'
+          }
         >
           {!done && (
             <FontAwesomeIcon
@@ -355,7 +361,7 @@ function EntryRow(props: {
               title="Not in your functions"
             />
           )}
-        </div>
+        </button>
       </div>
       {expanded && (
         <EditorBox>

--- a/src/components/options/LegacyBackup.tsx
+++ b/src/components/options/LegacyBackup.tsx
@@ -494,7 +494,7 @@ export function LegacyBackup() {
   // must stand on its own instead of an empty page.
   if (!status) {
     return error ? (
-      <Section title="Legacy storage backup">
+      <Section title="Legacy Functions">
         <div className={styles.error} role="alert">
           {error}
         </div>
@@ -507,7 +507,7 @@ export function LegacyBackup() {
   const summary = summaryText(raw, result);
 
   return (
-    <Section title="Legacy storage backup">
+    <Section title="Legacy Functions">
       <p className={styles.lead}>
         {MIGRATION_INTRO} This is the original data from before that move, kept
         so you can recover anything the automatic migration missed. It will be
@@ -587,28 +587,30 @@ export function LegacyBackupBanner() {
   const detail = failed ? (
     <>
       The automatic migration failed. Your original data is kept untouched
-      &mdash; recover it from the{' '}
-      <Link to="/legacy">Legacy storage backup</Link>.
+      &mdash; recover it from the <Link to="/legacy">Legacy Functions</Link>{' '}
+      page.
     </>
   ) : skippedCount > 0 ? (
     <>
       Your previous functions were migrated automatically, but {skippedCount}{' '}
       function(s) could not be carried over. Review and import them from the{' '}
-      <Link to="/legacy">Legacy storage backup</Link>.
+      <Link to="/legacy">Legacy Functions</Link> page.
     </>
   ) : (
     <>
       Your previous functions were migrated automatically. If anything is
       missing, review and recover the original data from the{' '}
-      <Link to="/legacy">Legacy storage backup</Link>.
+      <Link to="/legacy">Legacy Functions</Link> page.
     </>
   );
 
   return (
-    <div className={failed ? styles.bannerProblem : styles.banner}>
-      <p>{MIGRATION_INTRO}</p>
-      <p>{detail}</p>
-      <p>The original data will be removed in a future update.</p>
-    </div>
+    <Section title="Legacy Functions">
+      <div className={failed ? styles.bannerProblem : styles.banner}>
+        <p>{MIGRATION_INTRO}</p>
+        <p>{detail}</p>
+        <p>The original data will be removed in a future update.</p>
+      </div>
+    </Section>
   );
 }

--- a/src/components/options/Settings.module.css
+++ b/src/components/options/Settings.module.css
@@ -1,0 +1,7 @@
+.checkboxLabel {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--size-lg);
+  width: fit-content;
+}

--- a/src/components/options/Settings.test.tsx
+++ b/src/components/options/Settings.test.tsx
@@ -1,0 +1,76 @@
+import {act, fireEvent, render, screen, waitFor} from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import {CONFIG_KEY, createConfigStore} from '../../lib/config';
+import {InMemoryKeyValueStorage} from '../../lib/function-store/memory-storage';
+import {ConfigStoreProvider} from '../common/ConfigContext';
+import {Settings} from './Settings';
+
+function renderSettings(storage: InMemoryKeyValueStorage) {
+  const configStore = createConfigStore(storage);
+  return render(
+    <ConfigStoreProvider value={configStore}>
+      <Settings />
+    </ConfigStoreProvider>,
+  );
+}
+
+async function readConfig(storage: InMemoryKeyValueStorage): Promise<unknown> {
+  return (await storage.get([CONFIG_KEY]))[CONFIG_KEY];
+}
+
+test('renders unchecked when storage is empty', async () => {
+  const storage = new InMemoryKeyValueStorage();
+  renderSettings(storage);
+
+  const checkbox = await screen.findByRole('checkbox', {
+    name: 'Close the popup after copying',
+  });
+  expect(checkbox).not.toBeChecked();
+});
+
+test('renders checked when storage has closeAfterCopy: true', async () => {
+  const storage = new InMemoryKeyValueStorage();
+  await storage.set({[CONFIG_KEY]: {closeAfterCopy: true}});
+  renderSettings(storage);
+
+  const checkbox = await screen.findByRole('checkbox', {
+    name: 'Close the popup after copying',
+  });
+  await waitFor(() => expect(checkbox).toBeChecked());
+});
+
+test('clicking the checkbox writes closeAfterCopy: true to storage', async () => {
+  const storage = new InMemoryKeyValueStorage();
+  renderSettings(storage);
+
+  const checkbox = await screen.findByRole('checkbox', {
+    name: 'Close the popup after copying',
+  });
+  expect(checkbox).not.toBeChecked();
+
+  fireEvent.click(checkbox);
+  expect(checkbox).toBeChecked();
+
+  await waitFor(async () => {
+    expect(await readConfig(storage)).toMatchObject({closeAfterCopy: true});
+  });
+});
+
+test('reflects an external storage change via subscribe', async () => {
+  const storage = new InMemoryKeyValueStorage();
+  renderSettings(storage);
+
+  const checkbox = await screen.findByRole('checkbox', {
+    name: 'Close the popup after copying',
+  });
+  expect(checkbox).not.toBeChecked();
+
+  // Simulates a change made from another context (e.g. another options
+  // window), bypassing this component's own update().
+  await act(async () => {
+    await storage.set({[CONFIG_KEY]: {closeAfterCopy: true}});
+  });
+
+  await waitFor(() => expect(checkbox).toBeChecked());
+});

--- a/src/components/options/Settings.tsx
+++ b/src/components/options/Settings.tsx
@@ -1,0 +1,55 @@
+import {useCallback, useEffect, useState} from 'react';
+
+import {DEFAULT_CONFIG} from '../../lib/config';
+import {useConfigStore} from '../common/ConfigContext';
+import {Section} from './Parts';
+
+import styles from './Settings.module.css';
+
+export function Settings() {
+  const configStore = useConfigStore();
+  const [closeAfterCopy, setCloseAfterCopy] = useState(
+    DEFAULT_CONFIG.closeAfterCopy,
+  );
+
+  const load = useCallback(() => {
+    configStore
+      .read()
+      .then(config => setCloseAfterCopy(config.closeAfterCopy))
+      .catch(() => {
+        // Settings degrade to the default rather than failing the page.
+      });
+  }, [configStore]);
+
+  useEffect(() => {
+    load();
+    // Reflects changes made from another context (e.g. another options
+    // window), the same pattern as useSubscribeFunctions (Subscribe.ts).
+    return configStore.subscribe(load);
+  }, [configStore, load]);
+
+  const onChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const checked = event.currentTarget.checked;
+      setCloseAfterCopy(checked);
+      configStore.update({closeAfterCopy: checked}).catch(() => {
+        // Best-effort; the next subscribe/load cycle reconciles state.
+      });
+    },
+    [configStore],
+  );
+
+  return (
+    <Section title="Settings">
+      <label className={styles.checkboxLabel} htmlFor="closeAfterCopy">
+        <input
+          type="checkbox"
+          id="closeAfterCopy"
+          checked={closeAfterCopy}
+          onChange={onChange}
+        />
+        Close the popup after copying
+      </label>
+    </Section>
+  );
+}

--- a/src/components/options/test-helpers.tsx
+++ b/src/components/options/test-helpers.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import {MemoryRouter} from 'react-router-dom';
 
+import {createConfigStore} from '../../lib/config';
 import {CopyFunction} from '../../lib/function';
 import {FunctionStore} from '../../lib/function-store';
 import {InMemoryKeyValueStorage} from '../../lib/function-store/memory-storage';
 import {createLegacyBackupRepository} from '../../lib/function-store/migration';
 import {createFunctionRepository} from '../../lib/function-store/repository';
 import {seedSnapshot} from '../../lib/function-store/repository.test-helpers';
+import {ConfigStoreProvider} from '../common/ConfigContext';
 import {FunctionStoreProvider} from '../common/FunctionStoreContext';
 
 export interface TestStore extends FunctionStore {
@@ -42,9 +44,14 @@ export function renderWithStore(
   ui: React.ReactNode,
   initialEntries: string[] = ['/'],
 ): React.ReactElement {
+  // A dedicated in-memory ConfigStore keeps Settings (rendered by App/PageRoot)
+  // from falling back to getConfigStore() and touching real chrome.storage.
+  const configStore = createConfigStore(new InMemoryKeyValueStorage());
   return (
     <FunctionStoreProvider value={store}>
-      <MemoryRouter initialEntries={initialEntries}>{ui}</MemoryRouter>
+      <ConfigStoreProvider value={configStore}>
+        <MemoryRouter initialEntries={initialEntries}>{ui}</MemoryRouter>
+      </ConfigStoreProvider>
     </FunctionStoreProvider>
   );
 }

--- a/src/components/popup/App.test.tsx
+++ b/src/components/popup/App.test.tsx
@@ -2,6 +2,7 @@ import {render, screen, waitFor, fireEvent} from '@testing-library/react';
 import '@testing-library/jest-dom';
 import {vi, test, expect, afterEach} from 'vitest';
 
+import {ConfigStore, createConfigStore} from '../../lib/config';
 import {FunctionStore} from '../../lib/function-store';
 import {
   ACTIVE_POINTER_KEY,
@@ -14,6 +15,7 @@ import {
   makeFunction,
   seedSnapshot,
 } from '../../lib/function-store/repository.test-helpers';
+import {ConfigStoreProvider} from '../common/ConfigContext';
 import {FunctionStoreProvider} from '../common/FunctionStoreContext';
 import {App} from './App';
 
@@ -34,16 +36,37 @@ function buildStore(): {
   return {store: {repository, legacyBackup}, storage};
 }
 
-function renderApp(store: FunctionStore) {
+function buildConfigStore(): ConfigStore {
+  return createConfigStore(new InMemoryKeyValueStorage());
+}
+
+function renderApp(
+  store: FunctionStore,
+  configStore: ConfigStore = buildConfigStore(),
+) {
   return render(
-    <FunctionStoreProvider value={store}>
-      <App />
-    </FunctionStoreProvider>,
+    <ConfigStoreProvider value={configStore}>
+      <FunctionStoreProvider value={store}>
+        <App />
+      </FunctionStoreProvider>
+    </ConfigStoreProvider>,
   );
 }
 
+const clipboardWriteTextMock = vi.fn().mockResolvedValue(undefined);
+const clipboardWriteMock = vi.fn().mockResolvedValue(undefined);
+vi.stubGlobal('navigator', {
+  ...navigator,
+  clipboard: {
+    writeText: clipboardWriteTextMock,
+    write: clipboardWriteMock,
+  },
+});
+
 afterEach(() => {
   evaluateMock.mockReset();
+  clipboardWriteTextMock.mockClear();
+  clipboardWriteMock.mockClear();
 });
 
 test('lists only functions whose pattern matches the active tab URL, in Catalog order', async () => {
@@ -162,4 +185,100 @@ test('a document that fails to load shows an error but keeps other functions usa
   // The healthy function is still selectable and runs normally.
   fireEvent.click(screen.getByText(healthy.name));
   await waitFor(() => expect(evaluateMock).toHaveBeenCalledTimes(1));
+});
+
+test('closeAfterCopy=true closes the popup after the clipboard write completes', async () => {
+  vi.mocked(chrome.tabs.query).mockImplementation(
+    async () =>
+      [{id: 1, url: 'https://example.test/page'}] as chrome.tabs.Tab[],
+  );
+  vi.mocked(chrome.runtime.getManifest).mockImplementation(
+    () => ({version_name: 'Build v0.0.0'}) as chrome.runtime.Manifest,
+  );
+  vi.mocked(chrome.scripting.executeScript).mockImplementation(async () => []);
+  evaluateMock.mockResolvedValue({result: 'copied!'});
+  const closeSpy = vi.spyOn(window, 'close').mockImplementation(() => {});
+
+  const fn = makeFunction('runnable', {name: 'Run me'});
+  const {store, storage} = buildStore();
+  await seedSnapshot(storage, [fn]);
+  const configStore = buildConfigStore();
+  await configStore.update({closeAfterCopy: true});
+
+  renderApp(store, configStore);
+
+  await waitFor(() => expect(screen.getByText(fn.name)).toBeInTheDocument());
+  fireEvent.click(screen.getByText(fn.name));
+
+  await waitFor(() => expect(clipboardWriteTextMock).toHaveBeenCalledTimes(1));
+  // The clipboard write resolves well within the 300ms running animation;
+  // the popup must stay open until the animation finishes.
+  expect(closeSpy).not.toHaveBeenCalled();
+  await waitFor(() => expect(closeSpy).toHaveBeenCalledTimes(1));
+
+  // The clipboard write must complete before the popup closes.
+  expect(clipboardWriteTextMock.mock.invocationCallOrder[0]).toBeLessThan(
+    closeSpy.mock.invocationCallOrder[0],
+  );
+
+  closeSpy.mockRestore();
+});
+
+test('closeAfterCopy=false (default) does not close the popup after copying', async () => {
+  vi.mocked(chrome.tabs.query).mockImplementation(
+    async () =>
+      [{id: 1, url: 'https://example.test/page'}] as chrome.tabs.Tab[],
+  );
+  vi.mocked(chrome.runtime.getManifest).mockImplementation(
+    () => ({version_name: 'Build v0.0.0'}) as chrome.runtime.Manifest,
+  );
+  vi.mocked(chrome.scripting.executeScript).mockImplementation(async () => []);
+  evaluateMock.mockResolvedValue({result: 'copied!'});
+  const closeSpy = vi.spyOn(window, 'close').mockImplementation(() => {});
+
+  const fn = makeFunction('runnable', {name: 'Run me'});
+  const {store, storage} = buildStore();
+  await seedSnapshot(storage, [fn]);
+
+  renderApp(store);
+
+  await waitFor(() => expect(screen.getByText(fn.name)).toBeInTheDocument());
+  fireEvent.click(screen.getByText(fn.name));
+
+  await waitFor(() => expect(clipboardWriteTextMock).toHaveBeenCalledTimes(1));
+  expect(closeSpy).not.toHaveBeenCalled();
+
+  closeSpy.mockRestore();
+});
+
+test('closeAfterCopy=true does not close the popup when the function errors', async () => {
+  vi.mocked(chrome.tabs.query).mockImplementation(
+    async () =>
+      [{id: 1, url: 'https://example.test/page'}] as chrome.tabs.Tab[],
+  );
+  vi.mocked(chrome.runtime.getManifest).mockImplementation(
+    () => ({version_name: 'Build v0.0.0'}) as chrome.runtime.Manifest,
+  );
+  vi.mocked(chrome.scripting.executeScript).mockImplementation(async () => []);
+  evaluateMock.mockRejectedValue({
+    error: {type: 'ExecutionError', name: 'Error', message: 'boom'},
+  });
+  const closeSpy = vi.spyOn(window, 'close').mockImplementation(() => {});
+
+  const fn = makeFunction('runnable', {name: 'Run me'});
+  const {store, storage} = buildStore();
+  await seedSnapshot(storage, [fn]);
+  const configStore = buildConfigStore();
+  await configStore.update({closeAfterCopy: true});
+
+  renderApp(store, configStore);
+
+  await waitFor(() => expect(screen.getByText(fn.name)).toBeInTheDocument());
+  fireEvent.click(screen.getByText(fn.name));
+
+  await waitFor(() => expect(evaluateMock).toHaveBeenCalledTimes(1));
+  expect(closeSpy).not.toHaveBeenCalled();
+  expect(clipboardWriteTextMock).not.toHaveBeenCalled();
+
+  closeSpy.mockRestore();
 });

--- a/src/components/popup/FunctionList.tsx
+++ b/src/components/popup/FunctionList.tsx
@@ -1,5 +1,6 @@
-import {useState, useEffect, useCallback} from 'react';
+import {useState, useEffect, useCallback, useRef} from 'react';
 
+import {DEFAULT_CONFIG} from '../../lib/config';
 import {EvalResult, EvalError, isRichContent} from '../../lib/eval';
 import {
   CopyFunctionRef,
@@ -8,6 +9,7 @@ import {
 import {createPageTargetFromTab} from '../../lib/page';
 import {getActiveTab} from '../../lib/tab';
 import {codeToIndex} from '../../lib/util';
+import {useConfigStore} from '../common/ConfigContext';
 import {useFunctionRepository} from '../common/FunctionStoreContext';
 import {useEvaluate} from '../common/Sandbox';
 import {ListError} from './Error';
@@ -19,19 +21,27 @@ type FunctionError = {
   error: EvalError;
 } | null;
 
-function writeResultToClipboard(res: EvalResult) {
+// Must match animation-duration of `.running` in Function.module.css: the
+// popup stays open (even with closeAfterCopy) until the indicator finishes.
+const RUNNING_ANIMATION_MS = 300;
+
+/** Resolves once the clipboard write settles (or immediately, if there was
+ * nothing to copy), so callers can wait for it before closing the popup:
+ * window.close() can otherwise abort an in-flight clipboard write. */
+function writeResultToClipboard(res: EvalResult): Promise<void> {
   if (res.result) {
     if (isRichContent(res.result)) {
-      navigator.clipboard.write([
+      return navigator.clipboard.write([
         new ClipboardItem({
           'text/plain': new Blob([res.result.text], {type: 'text/plain'}),
           'text/html': new Blob([res.result.html], {type: 'text/html'}),
         }),
       ]);
     } else {
-      navigator.clipboard.writeText(res.result.toString());
+      return navigator.clipboard.writeText(res.result.toString());
     }
   }
+  return Promise.resolve();
 }
 
 /** Shown when `repository.get` returns undefined (document gone) or throws
@@ -64,11 +74,21 @@ function isEvalRejection(r: unknown): r is {error: EvalError} {
 export const FunctionList = () => {
   const evaluate = useEvaluate();
   const repository = useFunctionRepository();
+  const configStore = useConfigStore();
   const [functions, setFunctions] = useState<CopyFunctionRef[]>([]);
   const [running, setRunning] = useState<string | null>(null);
   const [fnError, setFnError] = useState<FunctionError>(null);
   const [listError, setListError] = useState<string | null>(null);
+  const [config, setConfig] = useState(DEFAULT_CONFIG);
   const modifier = useModifier();
+
+  // The running indicator is cleared by a timer; clear it on unmount so it
+  // never fires setState after the popup is gone (and a rapid second click
+  // does not get its indicator wiped by the first click's timer).
+  const runningTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+  useEffect(() => () => clearTimeout(runningTimer.current), []);
 
   useEffect(() => {
     const run = async () => {
@@ -88,10 +108,23 @@ export const FunctionList = () => {
       });
   }, [repository]);
 
+  useEffect(() => {
+    configStore.read().then(setConfig);
+  }, [configStore]);
+
   const onClick = useCallback(
     (ref: CopyFunctionRef) => {
       setRunning(ref.id);
-      setTimeout(() => setRunning(null), 300);
+      clearTimeout(runningTimer.current);
+      // Resolves when the running indicator finishes. Never resolves if a
+      // rapid second click replaces the timer, but then that click's own
+      // flow takes over closing the popup.
+      const animationDone = new Promise<void>(resolve => {
+        runningTimer.current = setTimeout(() => {
+          setRunning(null);
+          resolve();
+        }, RUNNING_ANIMATION_MS);
+      });
 
       const run = async () => {
         const tab = await getActiveTab();
@@ -110,7 +143,13 @@ export const FunctionList = () => {
         });
       };
       run()
-        .then(writeResultToClipboard)
+        .then(async res => {
+          await writeResultToClipboard(res);
+          if (config.closeAfterCopy) {
+            await animationDone;
+            window.close();
+          }
+        })
         .catch((r: unknown) =>
           setFnError({
             id: ref.id,
@@ -118,7 +157,7 @@ export const FunctionList = () => {
           }),
         );
     },
-    [evaluate, modifier, repository],
+    [config, evaluate, modifier, repository],
   );
 
   // Kyeboard Shortcut

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -1,0 +1,115 @@
+import {describe, expect, it, vi} from 'vitest';
+
+import {CONFIG_KEY, createConfigStore, DEFAULT_CONFIG} from './config';
+import {InMemoryKeyValueStorage} from './function-store/memory-storage';
+
+describe('createConfigStore', () => {
+  describe('read', () => {
+    it('returns DEFAULT_CONFIG when the key does not exist', async () => {
+      const storage = new InMemoryKeyValueStorage();
+      const store = createConfigStore(storage);
+      expect(await store.read()).toEqual(DEFAULT_CONFIG);
+    });
+
+    it('reads a normal stored value', async () => {
+      const storage = new InMemoryKeyValueStorage();
+      await storage.set({[CONFIG_KEY]: {closeAfterCopy: true}});
+      const store = createConfigStore(storage);
+      expect(await store.read()).toEqual({closeAfterCopy: true});
+    });
+
+    it('parses a value containing unknown fields, still reading closeAfterCopy', async () => {
+      const storage = new InMemoryKeyValueStorage();
+      await storage.set({
+        [CONFIG_KEY]: {
+          closeAfterCopy: true,
+          futureField: 'from a newer version',
+        },
+      });
+      const store = createConfigStore(storage);
+      expect(await store.read()).toEqual({closeAfterCopy: true});
+    });
+
+    it('falls back to the default when the stored value is not an object', async () => {
+      const storage = new InMemoryKeyValueStorage();
+      await storage.set({[CONFIG_KEY]: 'not an object'});
+      const store = createConfigStore(storage);
+      expect(await store.read()).toEqual(DEFAULT_CONFIG);
+    });
+
+    it('falls back closeAfterCopy to its default when the field is not a boolean', async () => {
+      const storage = new InMemoryKeyValueStorage();
+      await storage.set({[CONFIG_KEY]: {closeAfterCopy: 'yes'}});
+      const store = createConfigStore(storage);
+      expect(await store.read()).toEqual(DEFAULT_CONFIG);
+    });
+  });
+
+  describe('update', () => {
+    it('writes a value readable back through read()', async () => {
+      const storage = new InMemoryKeyValueStorage();
+      const store = createConfigStore(storage);
+      await store.update({closeAfterCopy: true});
+      expect(await store.read()).toEqual({closeAfterCopy: true});
+    });
+
+    it('preserves unknown existing fields in the raw stored value', async () => {
+      const storage = new InMemoryKeyValueStorage();
+      await storage.set({
+        [CONFIG_KEY]: {closeAfterCopy: false, futureField: 'keep me'},
+      });
+      const store = createConfigStore(storage);
+      await store.update({closeAfterCopy: true});
+
+      const raw = (await storage.get([CONFIG_KEY]))[CONFIG_KEY];
+      expect(raw).toEqual({closeAfterCopy: true, futureField: 'keep me'});
+    });
+
+    it('writes successfully when the key does not exist yet', async () => {
+      const storage = new InMemoryKeyValueStorage();
+      const store = createConfigStore(storage);
+      await store.update({closeAfterCopy: true});
+
+      const raw = (await storage.get([CONFIG_KEY]))[CONFIG_KEY];
+      expect(raw).toEqual({closeAfterCopy: true});
+    });
+  });
+
+  describe('subscribe', () => {
+    it('notifies the listener when CONFIG_KEY changes', async () => {
+      const storage = new InMemoryKeyValueStorage();
+      const store = createConfigStore(storage);
+      const listener = vi.fn();
+      store.subscribe(listener);
+
+      await store.update({closeAfterCopy: true});
+      await vi.waitFor(() => expect(listener).toHaveBeenCalledTimes(1));
+    });
+
+    it('does not notify the listener when another key changes', async () => {
+      const storage = new InMemoryKeyValueStorage();
+      const store = createConfigStore(storage);
+      const listener = vi.fn();
+      store.subscribe(listener);
+
+      await storage.set({'some:other:key': 1});
+      // Flush microtasks; the listener must not have fired for an unrelated key.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('stops notifying after unsubscribe', async () => {
+      const storage = new InMemoryKeyValueStorage();
+      const store = createConfigStore(storage);
+      const listener = vi.fn();
+      const unsubscribe = store.subscribe(listener);
+      unsubscribe();
+
+      await store.update({closeAfterCopy: true});
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,85 @@
+// Extension-wide user settings. Stored under its own storage.sync key,
+// separate from FunctionStore: its catalog is immutable copy-on-write, so
+// sharing a key would rewrite the catalog on every settings change.
+
+import * as v from 'valibot';
+
+import {ChromeKeyValueStorage} from './function-store/chrome-storage';
+import {KeyValueStorage, Unsubscribe} from './function-store/storage';
+
+export const CONFIG_KEY = 'cocopy:config';
+
+export interface Config {
+  closeAfterCopy: boolean;
+}
+
+export const DEFAULT_CONFIG: Config = {closeAfterCopy: false};
+
+// Forward-compatibility matters here, unlike FunctionStore: a config field
+// added by a newer extension version must not make an older version's read()
+// throw. Each field falls back to its own default independently, so one
+// corrupt field never invalidates the rest of the object.
+const configSchema = v.object({
+  closeAfterCopy: v.fallback(
+    v.optional(v.boolean(), DEFAULT_CONFIG.closeAfterCopy),
+    DEFAULT_CONFIG.closeAfterCopy,
+  ),
+});
+
+export interface ConfigStore {
+  read(): Promise<Config>;
+  /**
+   * Read-modify-write. Merges `patch` onto the raw stored value (not the
+   * parsed Config), so unknown fields written by a newer extension version
+   * survive an update from an older one.
+   */
+  update(patch: Partial<Config>): Promise<void>;
+  subscribe(listener: () => void): Unsubscribe;
+}
+
+function parseConfig(raw: unknown): Config {
+  if (typeof raw !== 'object' || raw === null) return {...DEFAULT_CONFIG};
+  const parsed = v.parse(configSchema, raw);
+  return {closeAfterCopy: parsed.closeAfterCopy};
+}
+
+export function createConfigStore(storage: KeyValueStorage): ConfigStore {
+  return {
+    async read(): Promise<Config> {
+      const raw = (await storage.get([CONFIG_KEY]))[CONFIG_KEY];
+      if (raw === undefined) return {...DEFAULT_CONFIG};
+      return parseConfig(raw);
+    },
+
+    async update(patch: Partial<Config>): Promise<void> {
+      const raw = (await storage.get([CONFIG_KEY]))[CONFIG_KEY];
+      const base =
+        typeof raw === 'object' && raw !== null
+          ? (raw as Record<string, unknown>)
+          : DEFAULT_CONFIG;
+      await storage.set({[CONFIG_KEY]: {...base, ...patch}});
+    },
+
+    subscribe(listener: () => void): Unsubscribe {
+      return storage.subscribe(changedKeys => {
+        if (changedKeys.includes(CONFIG_KEY)) listener();
+      });
+    },
+  };
+}
+
+let instance: ConfigStore | undefined;
+
+/**
+ * Returns the ConfigStore backed by chrome.storage.sync. Lazily constructed
+ * so that importing this module has no side effects (tests inject their own
+ * store instead of calling this).
+ */
+export function getConfigStore(): ConfigStore {
+  if (!instance) {
+    instance = createConfigStore(
+      new ChromeKeyValueStorage(chrome.storage.sync, 'sync'),
+    );
+  }
+  return instance;
+}


### PR DESCRIPTION
resolves #59

## Summary
- Adds a `closeAfterCopy` extension-wide setting (`src/lib/config.ts`), stored under its own `chrome.storage.sync` key separate from `FunctionStore`, with forward-compatible parsing (unknown/corrupt fields fall back to defaults independently).
- Adds a "Settings" section to the options page (`src/components/options/Settings.tsx`) with a checkbox to toggle the setting, kept in sync across contexts via `configStore.subscribe`.
- `FunctionList` now reads the setting and, when enabled, closes the popup window after a copy completes — waiting for the clipboard write and the running-indicator animation to finish first so `window.close()` doesn't abort an in-flight clipboard write or cut the indicator animation short.
- Renames "Legacy storage backup" to "Legacy Functions" throughout the options UI, and wraps `LegacyBackupBanner` in a `Section` for consistent styling with the rest of the options page.

## Test plan
- [x] `pnpm test` (Vitest + oxlint + oxfmt + tsc --noEmit)