### PR TITLE
wip: add temporary perf instrumentation for popup startup

### DIFF
--- a/src/components/popup/FunctionList.tsx
+++ b/src/components/popup/FunctionList.tsx
@@ -7,6 +7,7 @@ import {
   UnsupportedVersionError,
 } from '../../lib/function-store/types';
 import {createPageTargetFromTab} from '../../lib/page';
+import {timeIt} from '../../lib/perf-debug';
 import {getActiveTab} from '../../lib/tab';
 import {codeToIndex} from '../../lib/util';
 import {useConfigStore} from '../common/ConfigContext';
@@ -92,11 +93,11 @@ export const FunctionList = () => {
 
   useEffect(() => {
     const run = async () => {
-      const tab = await getActiveTab();
+      const tab = await timeIt('getActiveTab', getActiveTab());
       const url = tab.url || tab.pendingUrl || '';
-      return repository.listForUrl(url);
+      return timeIt('listForUrl', repository.listForUrl(url));
     };
-    run()
+    timeIt('FunctionList total', run())
       .then(setFunctions)
       .catch((e: unknown) => {
         console.error(e);

--- a/src/lib/function-store/repository.ts
+++ b/src/lib/function-store/repository.ts
@@ -2,6 +2,7 @@ import * as v from 'valibot';
 
 import {CopyFunction} from '../function';
 import {copyFunctionSchema} from '../function.schema';
+import {timeIt} from '../perf-debug';
 import {splitIntoShards} from './catalog';
 import {
   ACTIVE_POINTER_KEY,
@@ -321,13 +322,19 @@ export function createFunctionRepository(
     catalogId: string,
   ): Promise<Snapshot | undefined> {
     const rootKey = catalogRootKey(catalogId);
-    const rootRaw = (await storage.get([rootKey]))[rootKey];
+    const rootRaw = (await timeIt('root get', storage.get([rootKey])))[rootKey];
     if (rootRaw === undefined) return undefined;
 
     const root = parseOrThrow(catalogRootSchema, rootRaw, 'Catalog Root');
 
     const shardKeys = root.shardIds.map(catalogShardKey);
-    const shardsRaw = shardKeys.length > 0 ? await storage.get(shardKeys) : {};
+    const shardsRaw =
+      shardKeys.length > 0
+        ? await timeIt(
+            `shards get (${shardKeys.length})`,
+            storage.get(shardKeys),
+          )
+        : {};
 
     const shards: CatalogShard[] = [];
     for (const shardId of root.shardIds) {
@@ -352,14 +359,19 @@ export function createFunctionRepository(
    * ahead of the items it refers to).
    */
   async function readActiveSnapshot(): Promise<Snapshot> {
-    const catalogId = await requirePointer();
+    return timeIt('readActiveSnapshot total', readActiveSnapshotInner());
+  }
+
+  async function readActiveSnapshotInner(): Promise<Snapshot> {
+    const catalogId = await timeIt('pointer get', requirePointer());
+
     const snapshot = await readSnapshotFor(catalogId);
     if (snapshot) {
       // Do NOT claim catalogId as notified here: reads must never suppress a
       // change notification for other listeners. Only the commit path and the
       // change handler update notifiedCatalogId; an extra notification is a
       // harmless re-read, a missed one leaves a subscriber stale.
-      await writeCachedSnapshot(snapshot);
+      await timeIt('cache write', writeCachedSnapshot(snapshot));
       return snapshot;
     }
 

--- a/src/lib/perf-debug.ts
+++ b/src/lib/perf-debug.ts
@@ -1,0 +1,14 @@
+// Temporary instrumentation for investigating popup startup latency.
+// Not for production use — remove once the investigation is done.
+
+export async function timeIt<T>(
+  label: string,
+  promise: Promise<T>,
+): Promise<T> {
+  const t0 = performance.now();
+  try {
+    return await promise;
+  } finally {
+    console.log(`[perf] ${label}: ${(performance.now() - t0).toFixed(1)}ms`);
+  }
+}


### PR DESCRIPTION
## Summary
- Investigating occasional popup-open latency. Adds temporary instrumentation to time the popup's data-load path so we can capture a breakdown when it's slow.
- New `src/lib/perf-debug.ts`: `timeIt(label, promise)` wraps a promise, logs its duration via `console.log('[perf] ...')`.
- `FunctionList.tsx`: wraps `getActiveTab`, `repository.listForUrl`, and the overall effect with `timeIt`.
- `repository.ts`: wraps the Active Pointer read, Catalog Root read, Catalog Shard(s) read, and cache write inside `readActiveSnapshot`/`readSnapshotFor` with `timeIt`.

This is investigation-only and not intended to merge — logs to the console, no UI/behavior change. Will revert or close once we've captured a slow case and identified the bottleneck.

## Test plan
- [x] `pnpm run build` succeeds
- [ ] Reproduce a slow popup open and capture the `[perf]` log breakdown