### PR TITLE
fix: reduce expected test output

### DIFF
--- a/gallery/redirect/package.json
+++ b/gallery/redirect/package.json
@@ -5,6 +5,6 @@
   "license": "MIT",
   "main": "index.js",
   "engines": {
-    "node": "26.x"
+    "node": ">=24"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,11 +28,6 @@
       "oxfmt"
     ]
   },
-  "pnpm": {
-    "overrides": {
-      "@types/react": "19.2.18"
-    }
-  },
   "dependencies": {
     "@codemirror/autocomplete": "6.20.3",
     "@codemirror/lang-javascript": "6.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@types/react': 19.2.18
-
 importers:
 
   .:

--- a/src/components/popup/FunctionList.tsx
+++ b/src/components/popup/FunctionList.tsx
@@ -100,9 +100,10 @@ export const FunctionList = () => {
     timeIt('FunctionList total', run())
       .then(setFunctions)
       .catch((e: unknown) => {
-        console.error(e);
+        const unsupportedVersion = e instanceof UnsupportedVersionError;
+        if (!unsupportedVersion) console.error(e);
         setListError(
-          e instanceof UnsupportedVersionError
+          unsupportedVersion
             ? 'Your functions were saved by a newer version of cocopy. Update the extension.'
             : 'Failed to load functions.',
         );

--- a/src/lib/function-store/memory-storage.test.ts
+++ b/src/lib/function-store/memory-storage.test.ts
@@ -87,17 +87,29 @@ describe('InMemoryKeyValueStorage', () => {
   });
 
   it('isolates a throwing listener from other listeners', async () => {
-    const storage = new InMemoryKeyValueStorage();
-    const throwing = vi.fn(() => {
-      throw new Error('boom');
-    });
-    const other = vi.fn();
-    storage.subscribe(throwing);
-    storage.subscribe(other);
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
 
-    await storage.set({a: 1});
-    await vi.waitFor(() => expect(other).toHaveBeenCalledWith(['a']));
-    expect(throwing).toHaveBeenCalled();
+    try {
+      const storage = new InMemoryKeyValueStorage();
+      const throwing = vi.fn(() => {
+        throw new Error('boom');
+      });
+      const other = vi.fn();
+      storage.subscribe(throwing);
+      storage.subscribe(other);
+
+      await storage.set({a: 1});
+      await vi.waitFor(() => expect(other).toHaveBeenCalledWith(['a']));
+      expect(throwing).toHaveBeenCalled();
+      expect(consoleError).toHaveBeenCalledWith(
+        'InMemoryKeyValueStorage listener failed',
+        expect.any(Error),
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   describe('failOnce', () => {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -44,3 +44,11 @@ Object.defineProperty(Range.prototype, 'getClientRects', {
   configurable: true,
   value: () => [],
 });
+
+// Keep performance instrumentation enabled in production while avoiding
+// timing noise in tests that only assert behavior.
+vi.mock('./src/lib/perf-debug', () => ({
+  timeIt<T>(_label: string, promise: Promise<T>): Promise<T> {
+    return promise;
+  },
+}));


### PR DESCRIPTION
## Summary

- Suppress expected storage-version and test-only error/performance logs while preserving unexpected error logging.
- Align the gallery redirect function Node engine with the project requirement (Node >=24).
- Remove the redundant @types/react pnpm override from package.json and pnpm-lock.yaml.

## Validation

- pnpm install --frozen-lockfile --ignore-scripts
- pnpm test
- pnpm run check